### PR TITLE
Provide constant constructors to Eq and variants

### DIFF
--- a/lib/src/typeclass/eq.dart
+++ b/lib/src/typeclass/eq.dart
@@ -4,6 +4,8 @@
 /// Moreover, `eqv` should form an [equivalence relation](https://en.wikipedia.org/wiki/Equivalence_relation)
 /// (a binary relation that is reflexive, symmetric, and transitive).
 abstract class Eq<T> {
+  const Eq();
+
   /// Returns `true` if `x` and `y` are equivalent, `false` otherwise.
   bool eqv(T x, T y);
 

--- a/lib/src/typeclass/hash.dart
+++ b/lib/src/typeclass/hash.dart
@@ -5,6 +5,8 @@ import 'eq.dart';
 /// For any two instances `x` and `y` that are considered equivalent under the
 /// equivalence relation defined by this object, `hash(x)` should equal `hash(y)`.
 abstract class Hash<T> extends Eq<T> {
+  const Hash();
+
   /// Returns the hash code of the given object under this hashing scheme.
   int hash(T x);
 
@@ -17,7 +19,7 @@ class _Hash<T> extends Hash<T> {
   final bool Function(T x, T y) eq;
   final int Function(T x) hs;
 
-  _Hash(this.eq, this.hs);
+  const _Hash(this.eq, this.hs);
 
   @override
   bool eqv(T x, T y) => eq(x, y);

--- a/lib/src/typeclass/order.dart
+++ b/lib/src/typeclass/order.dart
@@ -19,6 +19,8 @@ import 'partial_order.dart';
 ///
 /// **By the totality law, `x <= y` and `y <= x` cannot be both false**.
 abstract class Order<T> extends PartialOrder<T> {
+  const Order();
+
   /// Result of comparing `x` with `y`. Returns an Int whose sign is:
   /// - negative iff `x < y`
   /// - zero     iff `x == y`

--- a/lib/src/typeclass/partial_order.dart
+++ b/lib/src/typeclass/partial_order.dart
@@ -23,6 +23,8 @@ import 'eq.dart';
 /// **Note**: A partial order under which every pair of elements is comparable
 /// is called a [total order](https://en.wikipedia.org/wiki/Total_order) ([Order]).
 abstract class PartialOrder<T> extends Eq<T> {
+  const PartialOrder();
+
   /// Result of comparing `x` with `y`.
   ///
   /// Returns `null` if operands are not comparable.


### PR DESCRIPTION
Sometimes we want to ensure that the same constant instance is used whenever we have some implemented behavior.

Example:

```dart

enum GreekLetter { alpha, beta, gama, delta }

class _GreekLetterOrder extends Order<GreekLetter> {
  const _GreekLetterOrder();

  @override
  int compare(GreekLetter a, GreekLetter b) => _internalValue[a]! - _internalValue[b]!;

  static const _internalValue = <GreekLetter, int>{
    GreekLetter.alpha: 1,
    GreekLetter.beta: 2,
    GreekLetter.gama: 3,
    GreekLetter.delta: 4,
  };
}

const GreekLetterOrder = _GreekLetterOrder();
```

This commits allow this by providing constant constructors for `Eq`, `PartialOrder`, `Order` and `Hash`.

It would be good if we could do it also with the other classes, like `Monoid` etc. However, it's not currently possible, as they are used as mixins.