### PR TITLE
Either right(), fixes #3

### DIFF
--- a/lib/src/either.dart
+++ b/lib/src/either.dart
@@ -227,7 +227,14 @@ abstract class Either<L, R> extends HKT2<_EitherHKT, L, R>
   factory Either.flatten(Either<L, Either<L, R>> e) => e.flatMap(identity);
 
   /// Return a `Right(r)`.
+  ///
+  /// Same as `Either.right(r)`.
   factory Either.of(R r) => Right(r);
+
+  /// Return a `Right(r)`.
+  ///
+  /// Same as `Either.of(r)`.
+  factory Either.right(R r) => Right(r);
 
   /// Return a `Left(l)`.
   factory Either.left(L l) => Left(l);

--- a/test/src/either_test.dart
+++ b/test/src/either_test.dart
@@ -559,6 +559,18 @@ void main() {
       value.match((l) => null, (r) => expect(r, 10));
     });
 
+    test('right()', () {
+      final value = Either<String, int>.right(10);
+      expect(value, isA<Right>());
+      value.match((l) => null, (r) => expect(r, 10));
+    });
+
+    test('of() == right()', () {
+      final of = Either<String, int>.of(10);
+      final right = Either<String, int>.right(10);
+      expect(of, right);
+    });
+
     test('left()', () {
       final value = Either<String, int>.left('none');
       expect(value, isA<Left>());


### PR DESCRIPTION
Added `Either.right(r)` factory constructor to `Either` class (same as `Either.of(r)`).