### PR TITLE
Add `TaskEither.tryCatchK`

### DIFF
--- a/lib/src/task_either.dart
+++ b/lib/src/task_either.dart
@@ -176,4 +176,19 @@ class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
           return Left<L, R>(onError(error, stack));
         }
       });
+
+  /// Converts a [Future] that may throw to a [Future] that never throws
+  /// but returns a [Either] instead.
+  ///
+  /// Used to handle asynchronous computations that may throw using [Either].
+  ///
+  /// It wraps the `TaskEither.tryCatch` factory to make chaining with `flatMap`
+  /// easier.
+  static TaskEither<L, R> Function(T a) tryCatchK<L, R, T>(
+          Future<R> Function(T a) run,
+          L Function(Object error, StackTrace stackTrace) onError) =>
+      (a) => TaskEither.tryCatch(
+            () => run(a),
+            onError,
+          );
 }

--- a/test/src/task_either_test.dart
+++ b/test/src/task_either_test.dart
@@ -30,6 +30,40 @@ void main() {
       });
     });
 
+    group('tryCatchK', () {
+      test('Success', () async {
+        final task = TaskEither<String, int>.right(10);
+        final ap = task.flatMap(TaskEither.tryCatchK(
+          (n) => Future.value(n + 5),
+          (_, __) => 'error',
+        ));
+        final r = await ap.run();
+        r.match((l) => null, (r) => expect(r, 15));
+      });
+
+      test('Failure', () async {
+        final task = TaskEither<String, int>.right(10);
+        final ap = task.flatMap(TaskEither.tryCatchK(
+          (n) => Future<int>.error(n + 5),
+          (_, __) => 'error',
+        ));
+        final r = await ap.run();
+        r.match((l) => expect(l, 'error'), (r) => null);
+      });
+
+      test('throws Exception', () async {
+        final task = TaskEither<String, int>.right(10);
+        final ap = task.flatMap(TaskEither.tryCatchK<String, int, int>((_) {
+          throw UnimplementedError();
+        }, (error, _) {
+          expect(error, isA<UnimplementedError>());
+          return 'error';
+        }));
+        final r = await ap.run();
+        r.match((l) => expect(l, 'error'), (r) => null);
+      });
+    });
+
     group('flatMap', () {
       test('Right', () async {
         final task = TaskEither<String, int>(() async => Either.of(10));


### PR DESCRIPTION
This makes it easier to chain `Future`s with `flatMap`.