### PR TITLE
Add `idFuture` and `identityFuture`

### DIFF
--- a/example/src/function/identity.dart
+++ b/example/src/function/identity.dart
@@ -1,6 +1,6 @@
 import 'package:fpdart/fpdart.dart';
 
-void main() {
+Future<void> main() async {
   final either = Either<String, int>.of(10);
 
   /// Without using `identity`, you must write a function to return
@@ -10,4 +10,12 @@ void main() {
   /// Using `identity`/`id`, the function just returns its input parameter.
   final withIdentity = either.match(identity, (r) => '$r');
   final withId = either.match(id, (r) => '$r');
+
+  /// Using `identityFuture`/`idFuture`, the function just returns its input
+  /// parameter, wrapped in `Future.value`.
+  final withIdentityFuture = await either.match(
+    identityFuture,
+    (r) async => '$r',
+  );
+  final withidFuture = await either.match(idFuture, (r) async => '$r');
 }

--- a/lib/src/function.dart
+++ b/lib/src/function.dart
@@ -36,6 +36,42 @@ T identity<T>(T a) => a;
 /// ```
 T id<T>(T a) => a;
 
+/// Returns the given `a`, wrapped in `Future.value`.
+///
+/// Same as `idFuture`.
+///
+/// Shortcut function to return the input parameter:
+/// ```dart
+/// final either = Either<String, int>.of(10);
+///
+/// /// Without using `identityFuture`, you must write a function to return
+/// /// the input parameter `(l) async => l`.
+/// final noId = await either.match((l) async => l, (r) async => '$r');
+///
+/// /// Using `identityFuture`/`idFuture`, the function just returns its input parameter.
+/// final withIdentityFuture = either.match(identityFuture, (r) async => '$r');
+/// final withIdFuture = await either.match(idFuture, (r) async => '$r');
+/// ```
+Future<T> identityFuture<T>(T a) => Future.value(a);
+
+/// Returns the given `a`, wrapped in `Future.value`.
+///
+/// Same as `identityFuture`.
+///
+/// Shortcut function to return the input parameter:
+/// ```dart
+/// final either = Either<String, int>.of(10);
+///
+/// /// Without using `idFuture`, you must write a function to return
+/// /// the input parameter `(l) async => l`.
+/// final noId = await either.match((l) async => l, (r) async => '$r');
+///
+/// /// Using `identityFuture`/`idFuture`, the function just returns its input parameter.
+/// final withIdentity = either.match(identityFuture, (r) async => '$r');
+/// final withId = await either.match(idFuture, (r) async => '$r');
+/// ```
+Future<T> idFuture<T>(T a) => Future.value(a);
+
 /// Returns the **first parameter** from a function that takes two parameters as input.
 T1 idFirst<T1, T2>(T1 t1, T2 t2) => t1;
 


### PR DESCRIPTION
Hi! First of all, thanks for this awesome package! It's a joy to use it!
The `id` function is pretty useful and I find myself using it more and more, however, in some cases, you need to do something asynchronous in the first callback, and just return the same value in the second. Currently there isn't a way to do that. 
In this PR I added two functions – `idFuture` and `identityFuture`, they are pretty much like their synchronous versions, but return the value, wrapped in `Future.value` instead.
