### PR TITLE
Refactor for mixin breaking change

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,5 +11,4 @@ analyzer:
     strict-raw-types: true
   errors:
     annotate_overrides: error
-    mixin_inherits_from_not_object: ignore
     deprecated_field: ignore

--- a/example/json_serializable/pubspec.lock
+++ b/example/json_serializable/pubspec.lock
@@ -175,7 +175,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.14"
+    version: "0.1.1"
   frontend_server_client:
     dependency: transitive
     description:

--- a/example/pokeapi_functional/pubspec.lock
+++ b/example/pokeapi_functional/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -126,7 +126,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
@@ -168,7 +168,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   file:
     dependency: transitive
     description:
@@ -213,7 +213,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.14"
+    version: "0.1.1"
   freezed:
     dependency: "direct main"
     description:
@@ -318,14 +318,14 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
@@ -346,7 +346,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   pedantic:
     dependency: transitive
     description:
@@ -414,7 +414,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -449,14 +449,14 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:

--- a/example/read_write_file/pubspec.lock
+++ b/example/read_write_file/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.13"
+    version: "0.1.1"
   lint:
     dependency: "direct dev"
     description:
@@ -16,4 +16,4 @@ packages:
     source: hosted
     version: "1.5.3"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
+  dart: ">=2.16.0 <3.0.0"

--- a/lib/src/either.dart
+++ b/lib/src/either.dart
@@ -25,6 +25,8 @@ abstract class _EitherHKT {}
 /// an instance of [Left] containing information about the kind of error that occurred.
 abstract class Either<L, R> extends HKT2<_EitherHKT, L, R>
     with
+        Functor2<_EitherHKT, L, R>,
+        Applicative2<_EitherHKT, L, R>,
         Monad2<_EitherHKT, L, R>,
         Foldable2<_EitherHKT, L, R>,
         Alt2<_EitherHKT, L, R>,

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -7,7 +7,8 @@ abstract class _IOHKT {}
 /// can **cause side effects**, yields a value of type `A` and **never fails**.
 ///
 /// If you want to represent a synchronous computation that may fail, see [IOEither].
-class IO<A> extends HKT<_IOHKT, A> with Monad<_IOHKT, A> {
+class IO<A> extends HKT<_IOHKT, A>
+    with Functor<_IOHKT, A>, Applicative<_IOHKT, A>, Monad<_IOHKT, A> {
   final A Function() _run;
 
   /// Build an instance of [IO] from `A Function()`.

--- a/lib/src/io_either.dart
+++ b/lib/src/io_either.dart
@@ -4,6 +4,8 @@ import 'io.dart';
 import 'option.dart';
 import 'task_either.dart';
 import 'typeclass/alt.dart';
+import 'typeclass/applicative.dart';
+import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
@@ -16,7 +18,11 @@ abstract class _IOEitherHKT {}
 ///
 /// If you want to represent a synchronous computation that may never fail, see [IO].
 class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
-    with Monad2<_IOEitherHKT, L, R>, Alt2<_IOEitherHKT, L, R> {
+    with
+        Functor2<_IOEitherHKT, L, R>,
+        Applicative2<_IOEitherHKT, L, R>,
+        Monad2<_IOEitherHKT, L, R>,
+        Alt2<_IOEitherHKT, L, R> {
   final Either<L, R> Function() _run;
 
   /// Build an instance of [IOEither] from `Either<L, R> Function()`.

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -3,10 +3,12 @@ import 'function.dart';
 import 'task_option.dart';
 import 'tuple.dart';
 import 'typeclass/alt.dart';
+import 'typeclass/applicative.dart';
 import 'typeclass/eq.dart';
 import 'typeclass/extend.dart';
 import 'typeclass/filterable.dart';
 import 'typeclass/foldable.dart';
+import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 import 'typeclass/monoid.dart';
@@ -63,6 +65,8 @@ abstract class _OptionHKT {}
 /// ```
 abstract class Option<T> extends HKT<_OptionHKT, T>
     with
+        Functor<_OptionHKT, T>,
+        Applicative<_OptionHKT, T>,
         Monad<_OptionHKT, T>,
         Foldable<_OptionHKT, T>,
         Alt<_OptionHKT, T>,

--- a/lib/src/reader.dart
+++ b/lib/src/reader.dart
@@ -6,7 +6,11 @@ abstract class ReaderHKT {}
 /// `Reader<R, A>` allows to read values `A` from a dependency/context `R`
 /// without explicitly passing the dependency between multiple nested
 /// function calls.
-class Reader<R, A> extends HKT2<ReaderHKT, R, A> with Monad2<ReaderHKT, R, A> {
+class Reader<R, A> extends HKT2<ReaderHKT, R, A>
+    with
+        Functor2<ReaderHKT, R, A>,
+        Applicative2<ReaderHKT, R, A>,
+        Monad2<ReaderHKT, R, A> {
   final A Function(R r) _read;
 
   /// Build a [Reader] given `A Function(R)`.

--- a/lib/src/state.dart
+++ b/lib/src/state.dart
@@ -12,7 +12,11 @@ abstract class _StateHKT {}
 /// `S` is a State (e.g. the current _State_ of your Bank Account).
 /// `A` is value that you _extract out of the [State]_
 /// (Account Balance fetched from the current state of your Bank Account `S`).
-class State<S, A> extends HKT2<_StateHKT, S, A> with Monad2<_StateHKT, S, A> {
+class State<S, A> extends HKT2<_StateHKT, S, A>
+    with
+        Functor2<_StateHKT, S, A>,
+        Applicative2<_StateHKT, S, A>,
+        Monad2<_StateHKT, S, A> {
   final Tuple2<A, S> Function(S state) _run;
 
   /// Build a new [State] given a `Tuple2<A, S> Function(S)`.

--- a/lib/src/state_async.dart
+++ b/lib/src/state_async.dart
@@ -15,7 +15,10 @@ abstract class _StateAsyncHKT {}
 ///
 /// Used when fetching and updating the state is **asynchronous**. Use [State] otherwise.
 class StateAsync<S, A> extends HKT2<_StateAsyncHKT, S, A>
-    with Monad2<_StateAsyncHKT, S, A> {
+    with
+        Functor2<_StateAsyncHKT, S, A>,
+        Applicative2<_StateAsyncHKT, S, A>,
+        Monad2<_StateAsyncHKT, S, A> {
   final Future<Tuple2<A, S>> Function(S state) _run;
 
   /// Build a new [StateAsync] given a `Future<Tuple2<A, S>> Function(S)`.

--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -6,14 +6,15 @@ abstract class _TaskHKT {}
 /// [Task] represents an asynchronous computation that yields a value of type `A` and **never fails**.
 ///
 /// If you want to represent an asynchronous computation that may fail, see [TaskEither].
-class Task<A> extends HKT<_TaskHKT, A> with Monad<_TaskHKT, A> {
+class Task<A> extends HKT<_TaskHKT, A>
+    with Functor<_TaskHKT, A>, Applicative<_TaskHKT, A>, Monad<_TaskHKT, A> {
   final Future<A> Function() _run;
 
   /// Build a [Task] from a function returning a [Future].
   const Task(this._run);
 
   /// Build a [Task] that returns `a`.
-  factory Task.of(A a) => Task(() async => a);
+  factory Task.of(A a) => Task<A>(() async => a);
 
   /// Flat a [Task] contained inside another [Task] to be a single [Task].
   factory Task.flatten(Task<Task<A>> task) => task.flatMap(identity);

--- a/lib/src/task_either.dart
+++ b/lib/src/task_either.dart
@@ -3,6 +3,8 @@ import 'function.dart';
 import 'option.dart';
 import 'task.dart';
 import 'typeclass/alt.dart';
+import 'typeclass/applicative.dart';
+import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
@@ -14,7 +16,11 @@ abstract class _TaskEitherHKT {}
 ///
 /// If you want to represent an asynchronous computation that never fails, see [Task].
 class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
-    with Monad2<_TaskEitherHKT, L, R>, Alt2<_TaskEitherHKT, L, R> {
+    with
+        Functor2<_TaskEitherHKT, L, R>,
+        Applicative2<_TaskEitherHKT, L, R>,
+        Monad2<_TaskEitherHKT, L, R>,
+        Alt2<_TaskEitherHKT, L, R> {
   final Future<Either<L, R>> Function() _run;
 
   /// Build a [TaskEither] from a function returning a `Future<Either<L, R>>`.

--- a/lib/src/task_option.dart
+++ b/lib/src/task_option.dart
@@ -3,6 +3,8 @@ import 'function.dart';
 import 'option.dart';
 import 'task.dart';
 import 'typeclass/alt.dart';
+import 'typeclass/applicative.dart';
+import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
@@ -17,7 +19,11 @@ abstract class _TaskOptionHKT {}
 /// If you want to represent an asynchronous computation that returns an object when it fails,
 /// see [TaskEither].
 class TaskOption<R> extends HKT<_TaskOptionHKT, R>
-    with Monad<_TaskOptionHKT, R>, Alt<_TaskOptionHKT, R> {
+    with
+        Functor<_TaskOptionHKT, R>,
+        Applicative<_TaskOptionHKT, R>,
+        Monad<_TaskOptionHKT, R>,
+        Alt<_TaskOptionHKT, R> {
   final Future<Option<R>> Function() _run;
 
   /// Build a [TaskOption] from a function returning a `Future<Option<R>>`.

--- a/lib/src/typeclass/alt.dart
+++ b/lib/src/typeclass/alt.dart
@@ -5,10 +5,10 @@ import 'hkt.dart';
 ///
 /// It provides an `alt` function used to return an alternative value when the
 /// current one represents a failure (for example, [None] for [Option]).
-abstract class Alt<KT, A> extends HKT<KT, A> with Functor<KT, A> {
+mixin Alt<KT, A> on HKT<KT, A>, Functor<KT, A> {
   HKT<KT, A> alt(HKT<KT, A> Function() orElse);
 }
 
-abstract class Alt2<KT, A, B> extends HKT2<KT, A, B> with Functor2<KT, A, B> {
+mixin Alt2<KT, A, B> on HKT2<KT, A, B>, Functor2<KT, A, B> {
   HKT2<KT, A, B> alt(HKT2<KT, A, B> Function() orElse);
 }

--- a/lib/src/typeclass/applicative.dart
+++ b/lib/src/typeclass/applicative.dart
@@ -1,7 +1,7 @@
 import 'functor.dart';
 import 'hkt.dart';
 
-abstract class Applicative<G, A> extends HKT<G, A> with Functor<G, A> {
+mixin Applicative<G, A> on HKT<G, A>, Functor<G, A> {
   HKT<G, B> pure<B>(B a);
   HKT<G, B> ap<B>(HKT<G, B Function(A a)> a);
 
@@ -9,8 +9,7 @@ abstract class Applicative<G, A> extends HKT<G, A> with Functor<G, A> {
   HKT<G, B> map<B>(B Function(A a) f) => ap(pure(f));
 }
 
-abstract class Applicative2<G, A, B> extends HKT2<G, A, B>
-    with Functor2<G, A, B> {
+mixin Applicative2<G, A, B> on HKT2<G, A, B>, Functor2<G, A, B> {
   HKT2<G, A, C> pure<C>(C a);
   HKT2<G, A, C> ap<C>(HKT2<G, A, C Function(B a)> a);
 

--- a/lib/src/typeclass/band.dart
+++ b/lib/src/typeclass/band.dart
@@ -3,7 +3,7 @@ import 'package:fpdart/fpdart.dart';
 /// Bands are semigroups whose operation
 /// (i.e. `combine`) is also [**idempotent**](https://en.wikipedia.org/wiki/Idempotence)
 /// (an operation that can be applied multiple times without changing the result beyond the initial application).
-abstract class Band<T> extends Semigroup<T> {
+mixin Band<T> on Semigroup<T> {
   /// Only apply `combine` operation the first time:
   /// - `n == 1`, then return `a`
   /// - Otherwise return `combine(a, a)`
@@ -21,7 +21,7 @@ abstract class Band<T> extends Semigroup<T> {
   static Band<A> instance<A>(A Function(A a1, A a2) f) => _Band(f);
 }
 
-class _Band<T> extends Band<T> {
+class _Band<T> with Semigroup<T>, Band<T> {
   final T Function(T x, T y) comb;
 
   _Band(this.comb);

--- a/lib/src/typeclass/bounded_semilattice.dart
+++ b/lib/src/typeclass/bounded_semilattice.dart
@@ -8,8 +8,7 @@ import 'package:fpdart/fpdart.dart';
 /// > of the set `{x, y}` exist.
 ///
 /// See also [Semilattice]
-abstract class BoundedSemilattice<T> extends CommutativeMonoid<T>
-    with Semilattice<T> {
+mixin BoundedSemilattice<T> on CommutativeMonoid<T>, Semilattice<T> {
   /// Return a `BoundedSemilattice` that reverses the order.
   @override
   BoundedSemilattice<T> reverse() =>
@@ -36,7 +35,15 @@ abstract class BoundedSemilattice<T> extends CommutativeMonoid<T>
       _BoundedSemilattice(emptyValue, f);
 }
 
-class _BoundedSemilattice<T> extends BoundedSemilattice<T> {
+class _BoundedSemilattice<T>
+    with
+        Semigroup<T>,
+        Monoid<T>,
+        CommutativeSemigroup<T>,
+        Band<T>,
+        Semilattice<T>,
+        CommutativeMonoid<T>,
+        BoundedSemilattice<T> {
   final T emp;
   final T Function(T x, T y) comb;
 

--- a/lib/src/typeclass/commutative_group.dart
+++ b/lib/src/typeclass/commutative_group.dart
@@ -4,14 +4,21 @@ import 'package:fpdart/fpdart.dart';
 /// is a group whose combine operation is [**commutative**](https://en.wikipedia.org/wiki/Commutative_property).
 ///
 /// See also [Group]
-abstract class CommutativeGroup<T> extends Group<T> with CommutativeMonoid<T> {
+mixin CommutativeGroup<T> on Group<T>, CommutativeMonoid<T> {
   /// Create a `CommutativeGroup` instance from the given function, empty value, and inverse function.
   static CommutativeGroup<A> instance<A>(
           A emptyValue, A Function(A a1, A a2) f, A Function(A a) inv) =>
       _CommutativeGroup(emptyValue, f, inv);
 }
 
-class _CommutativeGroup<T> extends CommutativeGroup<T> {
+class _CommutativeGroup<T>
+    with
+        Semigroup<T>,
+        CommutativeSemigroup<T>,
+        Monoid<T>,
+        CommutativeMonoid<T>,
+        Group<T>,
+        CommutativeGroup<T> {
   final T Function(T a) inv;
   final T emp;
   final T Function(T x, T y) comb;

--- a/lib/src/typeclass/commutative_monoid.dart
+++ b/lib/src/typeclass/commutative_monoid.dart
@@ -1,12 +1,12 @@
 import 'commutative_semigroup.dart';
 import 'monoid.dart';
+import 'semigroup.dart';
 
 /// `CommutativeMonoid` represents a commutative monoid.
 ///
 /// A monoid is [**commutative**](https://en.wikipedia.org/wiki/Commutative_property)
 /// if for all `x` and `y`, `combine(x, y) == combine(y, x)`.
-abstract class CommutativeMonoid<T> extends Monoid<T>
-    with CommutativeSemigroup<T> {
+mixin CommutativeMonoid<T> on Monoid<T>, CommutativeSemigroup<T> {
   /// Return a `CommutativeMonoid` that reverses the order.
   @override
   CommutativeMonoid<T> reverse() =>
@@ -18,7 +18,12 @@ abstract class CommutativeMonoid<T> extends Monoid<T>
       _CommutativeMonoid(emptyValue, f);
 }
 
-class _CommutativeMonoid<T> extends CommutativeMonoid<T> {
+class _CommutativeMonoid<T>
+    with
+        Semigroup<T>,
+        CommutativeSemigroup<T>,
+        Monoid<T>,
+        CommutativeMonoid<T> {
   final T emp;
   final T Function(T x, T y) comb;
 

--- a/lib/src/typeclass/commutative_semigroup.dart
+++ b/lib/src/typeclass/commutative_semigroup.dart
@@ -4,14 +4,14 @@ import 'package:fpdart/fpdart.dart';
 ///
 /// A semigroup is [**commutative**](https://en.wikipedia.org/wiki/Commutative_property)
 /// if for all `x` and `y`, `combine(x, y) == combine(y, x)`.
-abstract class CommutativeSemigroup<T> extends Semigroup<T> {
+mixin CommutativeSemigroup<T> on Semigroup<T> {
   /// Create a `CommutativeSemigroup` instance from the given function.
   // ignore: library_private_types_in_public_api
   static _CommutativeSemigroup<A> instance<A>(A Function(A a1, A a2) f) =>
       _CommutativeSemigroup(f);
 }
 
-class _CommutativeSemigroup<T> extends CommutativeSemigroup<T> {
+class _CommutativeSemigroup<T> with Semigroup<T>, CommutativeSemigroup<T> {
   final T Function(T x, T y) comb;
 
   _CommutativeSemigroup(this.comb);

--- a/lib/src/typeclass/extend.dart
+++ b/lib/src/typeclass/extend.dart
@@ -2,7 +2,7 @@ import '../function.dart';
 import 'functor.dart';
 import 'hkt.dart';
 
-abstract class Extend<KT, A> extends HKT<KT, A> with Functor<KT, A> {
+mixin Extend<KT, A> on HKT<KT, A>, Functor<KT, A> {
   /// Extend the type by applying function `f` to it.
   ///
   /// ```dart
@@ -13,9 +13,7 @@ abstract class Extend<KT, A> extends HKT<KT, A> with Functor<KT, A> {
 
   HKT<KT, HKT<KT, A>> duplicate() => extend(identity);
 }
-
-abstract class Extend2<KT, A, B> extends HKT2<KT, A, B>
-    with Functor2<KT, A, B> {
+mixin Extend2<KT, A, B> on HKT2<KT, A, B>, Functor2<KT, A, B> {
   /// Extend the type by applying function `f` to it.
   HKT2<KT, A, Z> extend<Z>(Z Function(HKT2<KT, A, B> t) f);
 

--- a/lib/src/typeclass/filterable.dart
+++ b/lib/src/typeclass/filterable.dart
@@ -5,7 +5,7 @@ import '../typedef.dart';
 import 'functor.dart';
 import 'hkt.dart';
 
-abstract class Filterable<KT, A> extends HKT<KT, A> with Functor<KT, A> {
+mixin Filterable<KT, A> on HKT<KT, A>, Functor<KT, A> {
   /// Filter a data structure based on a boolean predicate.
   HKT<KT, A> filter(bool Function(A a) f);
 

--- a/lib/src/typeclass/foldable.dart
+++ b/lib/src/typeclass/foldable.dart
@@ -3,7 +3,7 @@ import '../tuple.dart';
 import 'hkt.dart';
 import 'monoid.dart';
 
-abstract class Foldable<G, A> extends HKT<G, A> {
+mixin Foldable<G, A> on HKT<G, A> {
   B foldRight<B>(B b, B Function(B acc, A a) f);
 
   B foldLeft<B>(B b, B Function(B acc, A a) f) =>
@@ -46,7 +46,7 @@ abstract class Foldable<G, A> extends HKT<G, A> {
   HKT<G, A> append(A t);
 }
 
-abstract class Foldable2<G, A, B> extends HKT2<G, A, B> {
+mixin Foldable2<G, A, B> on HKT2<G, A, B> {
   C foldRight<C>(C b, C Function(C acc, B b) f);
 
   C foldLeft<C>(C b, C Function(C acc, B b) f) =>

--- a/lib/src/typeclass/functor.dart
+++ b/lib/src/typeclass/functor.dart
@@ -2,12 +2,12 @@ import 'hkt.dart';
 
 /// `Functor<G, A> extends HKT<G, A>` to express the fact that the classes implementing
 /// the [Functor] interface will need to be higher kinded types.
-abstract class Functor<G, A> extends HKT<G, A> {
+mixin Functor<G, A> on HKT<G, A> {
   /// Return type is `HKT<G, B>`, which expresses the fact that what
   /// we return is using exactly the same type constructor represented by the brand `G`
   HKT<G, B> map<B>(B Function(A a) f);
 }
 
-abstract class Functor2<G, A, B> extends HKT2<G, A, B> {
+mixin Functor2<G, A, B> on HKT2<G, A, B> {
   HKT2<G, A, C> map<C>(C Function(B a) f);
 }

--- a/lib/src/typeclass/group.dart
+++ b/lib/src/typeclass/group.dart
@@ -1,7 +1,7 @@
 import 'package:fpdart/fpdart.dart';
 
 /// A group is a monoid where each element has an [**inverse**](https://en.wikipedia.org/wiki/Inverse_element).
-abstract class Group<T> extends Monoid<T> {
+mixin Group<T> on Monoid<T> {
   /// Find the inverse of `a`.
   ///
   /// `combine(a, inverse(a))` == `combine(inverse(a), a)` == `empty`
@@ -39,7 +39,7 @@ abstract class Group<T> extends Monoid<T> {
       _Group(emptyValue, f, inv);
 }
 
-class _Group<T> extends Group<T> {
+class _Group<T> with Semigroup<T>, Monoid<T>, Group<T> {
   final T Function(T a) inv;
   final T emp;
   final T Function(T x, T y) comb;

--- a/lib/src/typeclass/monad.dart
+++ b/lib/src/typeclass/monad.dart
@@ -1,7 +1,7 @@
 import 'applicative.dart';
 import 'hkt.dart';
 
-abstract class Monad<KT, A> extends HKT<KT, A> with Applicative<KT, A> {
+mixin Monad<KT, A> on HKT<KT, A>, Applicative<KT, A> {
   HKT<KT, B> flatMap<B>(HKT<KT, B> Function(A a) f);
 
   @override
@@ -23,8 +23,7 @@ abstract class Monad<KT, A> extends HKT<KT, A> with Applicative<KT, A> {
   HKT<KT, B> call<B>(HKT<KT, B> chain) => flatMap((_) => chain);
 }
 
-abstract class Monad2<KT, A, B> extends HKT2<KT, A, B>
-    with Applicative2<KT, A, B> {
+mixin Monad2<KT, A, B> on HKT2<KT, A, B>, Applicative2<KT, A, B> {
   HKT2<KT, A, C> flatMap<C>(HKT2<KT, A, C> Function(B a) f);
 
   /// Derive `ap` from `flatMap`.

--- a/lib/src/typeclass/monoid.dart
+++ b/lib/src/typeclass/monoid.dart
@@ -19,7 +19,7 @@ import 'semigroup.dart';
 /// expect(instance.combine('abc', instance.empty), instance.combine(instance.empty, 'abc'));
 /// expect(instance.combine('abc', instance.empty), 'abc');
 /// ```
-abstract class Monoid<T> extends Semigroup<T> {
+mixin Monoid<T> on Semigroup<T> {
   /// Return the identity element for this monoid.
   T get empty;
 
@@ -80,7 +80,7 @@ abstract class Monoid<T> extends Semigroup<T> {
       _Monoid(emptyValue, f);
 }
 
-class _Monoid<T> extends Monoid<T> {
+class _Monoid<T> with Semigroup<T>, Monoid<T> {
   final T emp;
   final T Function(T x, T y) comb;
 

--- a/lib/src/typeclass/semigroup.dart
+++ b/lib/src/typeclass/semigroup.dart
@@ -1,7 +1,7 @@
 /// A semigroup is any set `A` with an [**associative operation**](https://en.wikipedia.org/wiki/Associative_property) (`combine`).
 ///
 /// `(xy)z = x(yz) = xyz` for all `x`, `y`, `z` in `A`
-abstract class Semigroup<T> {
+mixin Semigroup<T> {
   /// Associative operation which combines two values.
   ///
   /// ```dart
@@ -82,7 +82,7 @@ abstract class Semigroup<T> {
   static Semigroup<A> last<A>() => _Semigroup((x, y) => y);
 }
 
-class _Semigroup<T> extends Semigroup<T> {
+class _Semigroup<T> with Semigroup<T> {
   final T Function(T x, T y) comb;
 
   _Semigroup(this.comb);

--- a/lib/src/typeclass/semilattice.dart
+++ b/lib/src/typeclass/semilattice.dart
@@ -2,6 +2,7 @@ import 'band.dart';
 import 'commutative_semigroup.dart';
 import 'eq.dart';
 import 'partial_order.dart';
+import 'semigroup.dart';
 
 /// [**Semilattices**](https://en.wikipedia.org/wiki/Semilattice)
 /// are commutative semigroups whose operation
@@ -16,7 +17,7 @@ import 'partial_order.dart';
 /// > of the set `{x, y}` exists.
 ///
 /// See also [CommutativeSemigroup], [Bind].
-abstract class Semilattice<T> extends Band<T> with CommutativeSemigroup<T> {
+mixin Semilattice<T> on Band<T>, CommutativeSemigroup<T> {
   /// Given `Eq<T>`, return a `PartialOrder<T>` using the `combine`
   /// operator of `Semilattice` to determine the partial ordering. This method assumes
   /// `combine` functions as `meet` (that is, as a **lower bound**).
@@ -70,7 +71,8 @@ abstract class Semilattice<T> extends Band<T> with CommutativeSemigroup<T> {
       _Semilattice(f);
 }
 
-class _Semilattice<T> extends Semilattice<T> {
+class _Semilattice<T>
+    with Semigroup<T>, CommutativeSemigroup<T>, Band<T>, Semilattice<T> {
   final T Function(T x, T y) comb;
 
   _Semilattice(this.comb);


### PR DESCRIPTION
Fixes #41
Mixins will no longer be able to extend other mixins (Rather the super mixin should be specified in an on clause). This breaking change is already on flutter's master channel, which is causing build errors when depending on this library. 
https://github.com/dart-lang/sdk/issues/48167

This change makes the mixin clause longer for many of the classes, but at least the tests seem to still pass. Other than one test which I'm assuming is related to this issue, which is already resolved on dart's master channel.
https://github.com/dart-lang/sdk/commit/abedfaf62a2a426d44142dc97aa342524feedf8f
