### PR TITLE
Implement Sequence method for Either type only

### DIFF
--- a/example/src/either/sequence.dart
+++ b/example/src/either/sequence.dart
@@ -1,10 +1,14 @@
 import 'package:fpdart/fpdart.dart';
-
+import 'package:fpdart/src/typeclass/traversable.dart';
 /// Sequence allows you to unwrap a List of Eithers to an Either of List.
 /// It has the type signature (List<Either<L, R>>) => Either<L, List<R>>
 /// If any member of the list is a Left type, then the result will be the first Left
 /// type sequence encounters
 /// If all members of the list are Right, then the result will be a Right<List>>
 void main() {
-  // final 
+  final unwrappedList = sequenceEither([Either.right(1), Either.right(2)]);
+  if (unwrappedList.isRight()) {
+    // Outputs [1, 2]
+    print(unwrappedList.getRight().getOrElse(() => []));
+  }
 }

--- a/example/src/either/sequence.dart
+++ b/example/src/either/sequence.dart
@@ -1,0 +1,10 @@
+import 'package:fpdart/fpdart.dart';
+
+/// Sequence allows you to unwrap a List of Eithers to an Either of List.
+/// It has the type signature (List<Either<L, R>>) => Either<L, List<R>>
+/// If any member of the list is a Left type, then the result will be the first Left
+/// type sequence encounters
+/// If all members of the list are Right, then the result will be a Right<List>>
+void main() {
+  // final 
+}

--- a/lib/src/either.dart
+++ b/lib/src/either.dart
@@ -91,6 +91,8 @@ abstract class Either<L, R> extends HKT2<_EitherHKT, L, R>
   Either<L, C> map<C>(C Function(R a) f);
 
   /// Return a [Right] containing the value `c`.
+  /// This is a bit like Either.of or Either.right
+  /// but works on an instance type
   @override
   Either<L, C> pure<C>(C c) => Right<L, C>(c);
 

--- a/lib/src/typeclass/traversable.dart
+++ b/lib/src/typeclass/traversable.dart
@@ -2,9 +2,56 @@ import 'applicative.dart';
 import 'foldable.dart';
 import 'functor.dart';
 import 'hkt.dart';
+import 'package:fpdart/fpdart.dart';
 
 abstract class Traversable<KT, A> extends HKT<KT, A>
     with Functor<KT, A>, Foldable<KT, A> {
   HKT<ZKT, HKT<KT, Z>> traverse<Z, ZKT>(
       Applicative<ZKT, Z> applicative, HKT<ZKT, Z> Function(A a) f);
+}
+
+/// TODO: generalise this to an abstract interface that can be implemented
+/// for each data type individually
+
+/// This allows us to take a generic either, and inspect the internal values
+/// If you use getRight or getLeft you get an option type back
+/// The only way to unwrap an option is to either provide a callback to getOrElse
+/// which would require knowledge of the generic types L, R which is not known
+/// Or to provide a lot of messy nested if statements and calls to Option.value()
+class UnwrapEither<L, R> { 
+  L? leftValue;
+  R? rightValue;
+  UnwrapEither(this.leftValue, this.rightValue);
+  static UnwrapEither fromEither<L, R>(Either<L, R> e) {
+    return e.match(
+      (l) => UnwrapEither(l, null),
+      (r) => UnwrapEither(null, r)
+    );
+  }
+}
+
+/// This function takes a List of Eithers and returns an Either of List.
+/// If every item in the list is Right, then you will get a List of the unwrapped
+/// values.
+/// If not, it will return the first Left type it encounters
+/// ```dart
+/// final unwrappedList = sequenceEither([Either.right(1), Either.right(2)]);
+/// if (unwrappedList.isRight()) {
+///   print(unwrappedList.getRight().value());
+/// }
+/// ```
+/// which outputs '[1, 2]'
+Either<L, List<R>> sequenceEither<L, R>(List<Either<L, R>> l) {
+  // If any are left, return first left
+  final items = <R>[];
+  for (final item in l) {
+    final result = UnwrapEither.fromEither(item);
+    if (result.rightValue != null) {
+      items.add(result.rightValue);
+    } else {
+      return Either.left(result.leftValue);
+    }
+  }
+  // Otherwise unwrap all rights
+  return Either.right(items);
 }

--- a/lib/src/typeclass/traversable.dart
+++ b/lib/src/typeclass/traversable.dart
@@ -17,7 +17,6 @@ abstract class Traversable<KT, A> extends HKT<KT, A>
 /// If you use getRight or getLeft you get an option type back
 /// The only way to unwrap an option is to either provide a callback to getOrElse
 /// which would require knowledge of the generic types L, R which is not known
-/// Or to provide a lot of messy nested if statements and calls to Option.value()
 class UnwrapEither<L, R> { 
   L? leftValue;
   R? rightValue;

--- a/lib/src/typeclass/traversable.dart
+++ b/lib/src/typeclass/traversable.dart
@@ -37,7 +37,8 @@ class UnwrapEither<L, R> {
 /// ```dart
 /// final unwrappedList = sequenceEither([Either.right(1), Either.right(2)]);
 /// if (unwrappedList.isRight()) {
-///   print(unwrappedList.getRight().value());
+///   // Outputs [1, 2]
+///   print(unwrappedList.getRight().getOrElse(() => []));
 /// }
 /// ```
 /// which outputs '[1, 2]'

--- a/test/src/either_test.dart
+++ b/test/src/either_test.dart
@@ -827,13 +827,4 @@ void main() {
       expect(sideEffect, 100);
     });
   });
-
-  group('sequence', () {
-    test('all rights', () {
-      final listOfEithers = [Either.right(1), Either.right(2), Either.right(3)];
-      final result = sequenceEither(listOfEithers);
-      expect(result.isRight(), true);
-      expect(result.getRight(), Option.of([1, 2, 3]));
-    });
-  });
 }

--- a/test/src/either_test.dart
+++ b/test/src/either_test.dart
@@ -827,4 +827,13 @@ void main() {
       expect(sideEffect, 100);
     });
   });
+
+  group('sequence', () {
+    test('all rights', () {
+      final listOfEithers = [Either.right(1), Either.right(2), Either.right(3)];
+      final result = sequenceEither(listOfEithers);
+      expect(result.isRight(), true);
+      expect(result.getRight(), Option.of([1, 2, 3]));
+    });
+  });
 }

--- a/test/typeclass/traversable_test.dart
+++ b/test/typeclass/traversable_test.dart
@@ -1,0 +1,20 @@
+import 'package:test/test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:fpdart/src/typeclass/traversable.dart';
+
+void main() {
+  group('either', () {
+    test('all rights', () {
+      final listOfEithers = [Either.right(1), Either.right(2), Either.right(3)];
+      final result = sequenceEither(listOfEithers);
+      expect(result.isRight(), true);
+      expect(result.getOrElse((l) => []), [1, 2, 3]);
+    });
+    test('one left', () {
+      final listOfEithers = [Either.right(1), Either.left(2), Either.right(3)];
+      final result = sequenceEither(listOfEithers);
+      expect(result.isRight(), false);
+      expect(result.getLeft(), Option.of(2));
+    });
+  });
+}


### PR DESCRIPTION
## Context

Coming from a fp-ts background, I'm accustomed to be able to perform operations like sequenceT:

```ts
const prog = pipe(
  arrayOfItems.map((item) => {
    return TE.tryCatch(
      async () => {
        return await fetch(`/some/api?input=${item}`);
      },
      (e) => new Error('Error')
    );
  }),
  TE.sequenceT
);
```

In other words, maybe I need to hit an API multiple times with a bunch of inputs, so this is an array of TaskEithers, but at the end of the day, I just want to abstract that out, await this task once, and get back the array of responses.

I looked through the library for quite a long time and couldn't find anything like that in there yet, so I presumed that it's either called something else, or can be constructed somehow using Dart type magic, or just hasn't been implemented yet.

## Approach

I'm quite new to Dart and am not fully up to speed with the Type system yet.

My understanding is that a better long-term solution is to implement some kind of abstract interface for sequence, then each type (like Either, TaskEither, Option etc) would provide some kind of method for how to implement a particular step in the sequence combinator.

I don't know how to do this yet, and also for my project I just need to unwrap Lists of Eithers at the moment.  So I will be using this function in my code until this has been resolved in this project.

It's more of a suggestion at this stage, and I'm happy to take some feedback as to how to better integrate this feature into the package and work on a more comprehensive solution.


