### PR TITLE
Option `match` invert `onNone` and `onSome`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ final value = option.getOrElse(() => -1);
 
 /// Pattern matching
 final match = option.match(
-  (a) => print('Some($a)'),
   () => print('None'),
+  (a) => print('Some($a)'),
 );
 
 /// Convert to [Either]

--- a/example/from_imperative_to_functional/logger/main.dart
+++ b/example/from_imperative_to_functional/logger/main.dart
@@ -2,8 +2,8 @@
 /// from Imperative to Functional code using `fpdart`
 ///
 /// Repository: https://github.com/leisim/logger
-
 import 'package:fpdart/fpdart.dart';
+
 import 'logger.dart';
 
 class Logger {
@@ -87,11 +87,17 @@ IOEither<String, Unit> logFunctional({
 
   /// Using [Option], you must specify both `true` and `false` cases 🌎
   return shouldLogOption.match(
+    /// Simply return a [Unit] in the else case 🎁
+    () => IOEither.of(unit),
+
     /// Use another [Option] to evaluate `printer.log`
     (_) => Option<List<String>>.fromPredicate(
       printer.log(logEvent),
       (v) => v.isNotEmpty,
     ).match(
+      /// Simply return a [Unit] in the else case 🎁
+      () => IOEither.of(unit),
+
       (lines) {
         /// All variables are `final` 🧱
         final outputEvent = OutputEvent(level, lines);
@@ -110,12 +116,6 @@ IOEither<String, Unit> logFunctional({
           },
         );
       },
-
-      /// Simply return a [Unit] in the else case 🎁
-      () => IOEither.of(unit),
     ),
-
-    /// Simply return a [Unit] in the else case 🎁
-    () => IOEither.of(unit),
   );
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -73,8 +73,8 @@ void option() {
 
   /// Pattern matching
   final match = option.match(
-    (a) => print('Some($a)'),
     () => print('None'),
+    (a) => print('Some($a)'),
   );
 
   /// Convert to [Either]

--- a/example/src/option/get-price/functional.dart
+++ b/example/src/option/get-price/functional.dart
@@ -11,11 +11,11 @@ Option<int> getPrice(String productName) {
 void main() {
   final price = getPrice('my product name');
   price.match(
-    (a) {
-      print('Total price is: $price');
-    },
     () {
       print('Sorry, no product found!');
+    },
+    (a) {
+      print('Total price is: $price');
     },
   );
 }

--- a/example/src/option/option1.dart
+++ b/example/src/option/option1.dart
@@ -24,7 +24,7 @@ void main() {
   /// Using [Option] you are required to specify every possible case.
   /// The type system helps you to find and define edge-cases and avoid errors.
   mStr.match(
-    printString,
     () => print('I have no string to print 🤷‍♀️'),
+    printString,
   );
 }

--- a/example/src/option/overview.dart
+++ b/example/src/option/overview.dart
@@ -49,8 +49,8 @@ void main() {
 
   /// Pattern matching
   final match = option.match(
-    (a) => print('Some($a)'),
     () => print('None'),
+    (a) => print('Some($a)'),
   );
 
   /// Convert to [Either]

--- a/lib/src/either.dart
+++ b/lib/src/either.dart
@@ -312,8 +312,10 @@ abstract class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// Return an [Either] from a [Option]:
   /// - If [Option] is [Some], then return [Right] containing its value
   /// - If [Option] is [None], then return [Left] containing the result of `onNone`
-  factory Either.fromOption(Option<R> m, L Function() onNone) =>
-      m.match((r) => Either.of(r), () => Either.left(onNone()));
+  factory Either.fromOption(Option<R> m, L Function() onNone) => m.match(
+        () => Either.left(onNone()),
+        (r) => Either.of(r),
+      );
 
   /// If calling `predicate` with `r` returns `true`, then return `Right(r)`.
   /// Otherwise return [Left] containing the result of `onFalse`.

--- a/lib/src/io_either.dart
+++ b/lib/src/io_either.dart
@@ -190,7 +190,10 @@ class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
   /// When `option` is [Some], then return [Right] when
   /// running [IOEither]. Otherwise return `onNone`.
   factory IOEither.fromOption(Option<R> option, L Function() onNone) =>
-      IOEither(() => option.match((r) => Right(r), () => Left(onNone())));
+      IOEither(() => option.match(
+            () => Left(onNone()),
+            Right.new,
+          ));
 
   /// Build a [IOEither] that returns `either`.
   factory IOEither.fromEither(Either<L, R> either) => IOEither(() => either);

--- a/lib/src/list_extension.dart
+++ b/lib/src/list_extension.dart
@@ -231,14 +231,26 @@ extension FpdartOnMutableIterable<T> on Iterable<T> {
   /// The largest element of this [Iterable] based on `order`.
   ///
   /// If the list is empty, return [None].
-  Option<T> maximumBy(Order<T> order) => foldLeft(none(),
-      (a, c) => some(a.match((t) => order.compare(c, t) > 0 ? c : t, () => c)));
+  Option<T> maximumBy(Order<T> order) => foldLeft(
+      none(),
+      (a, c) => some(
+            a.match(
+              () => c,
+              (t) => order.compare(c, t) > 0 ? c : t,
+            ),
+          ));
 
   /// The least element of this [Iterable] based on `order`.
   ///
   /// If the list is empty, return [None].
-  Option<T> minimumBy(Order<T> order) => foldLeft(none(),
-      (a, c) => some(a.match((t) => order.compare(c, t) < 0 ? c : t, () => c)));
+  Option<T> minimumBy(Order<T> order) => foldLeft(
+      none(),
+      (a, c) => some(
+            a.match(
+              () => c,
+              (t) => order.compare(c, t) < 0 ? c : t,
+            ),
+          ));
 
   /// Checks whether every element of this [Iterable] satisfies [test].
   ///

--- a/lib/src/map_extension.dart
+++ b/lib/src/map_extension.dart
@@ -284,8 +284,8 @@ extension FpdartOnMutableMap<K, V> on Map<K, V> {
       (Map<K, V> map) => map.foldLeftWithKey<Map<K, V>>(Order.allEqual())(
             {},
             (acc, key, value) => lookup(key).match(
-              (v) => acc.upsertAt(eq)(key, combine(v, value)),
               () => acc,
+              (v) => acc.upsertAt(eq)(key, combine(v, value)),
             ),
           );
 

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -171,8 +171,10 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
   /// final result = b.ap(map);
   /// ```
   @override
-  Option<B> ap<B>(covariant Option<B Function(T t)> a) =>
-      a.match((f) => map(f), () => Option.none());
+  Option<B> ap<B>(covariant Option<B Function(T t)> a) => a.match(
+        () => Option.none(),
+        (f) => map(f),
+      );
 
   /// Return a [Some] containing the value `b`.
   @override
@@ -298,7 +300,7 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
   /// [🍌].match((🍌) => 🍌 * 2, () => 🍎) -> 🍌🍌
   /// [_].match((🍌) => 🍌 * 2, () => 🍎) -> 🍎
   /// ```
-  B match<B>(B Function(T t) onSome, B Function() onNone);
+  B match<B>(B Function() onNone, B Function(T t) onSome);
 
   /// Return `true` when value is [Some].
   bool isSome();
@@ -353,7 +355,7 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
     final resultList = <B>[];
     for (var i = 0; i < list.length; i++) {
       final o = f(list[i], i);
-      final r = o.match<B?>(identity, () => null);
+      final r = o.match<B?>(() => null, identity);
       if (r == null) return none();
       resultList.add(r);
     }
@@ -431,8 +433,10 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
   /// The value on the left of the [Either] will be the first value of the tuple,
   /// while the right value of the [Either] will be the second of the tuple.
   static Tuple2<Option<A>, Option<B>> separate<A, B>(Option<Either<A, B>> m) =>
-      m.match((either) => Tuple2(either.getLeft(), either.getRight()),
-          () => Tuple2(Option.none(), Option.none()));
+      m.match(
+        () => Tuple2(Option.none(), Option.none()),
+        (either) => Tuple2(either.getLeft(), either.getRight()),
+      );
 
   /// Build an `Eq<Option>` by comparing the values inside two [Option].
   ///
@@ -526,7 +530,7 @@ class Some<T> extends Option<T> {
   Option<T> alt(Option<T> Function() orElse) => this;
 
   @override
-  B match<B>(B Function(T t) onSome, B Function() onNone) => onSome(_value);
+  B match<B>(B Function() onNone, B Function(T t) onSome) => onSome(_value);
 
   @override
   Option<Z> extend<Z>(Z Function(Option<T> t) f) => Some(f(this));
@@ -541,8 +545,10 @@ class Some<T> extends Option<T> {
   Option<T> filter(bool Function(T t) f) => f(_value) ? this : Option.none();
 
   @override
-  Option<Z> filterMap<Z>(Option<Z> Function(T t) f) =>
-      f(_value).match((a) => Some(a), () => Option.none());
+  Option<Z> filterMap<Z>(Option<Z> Function(T t) f) => f(_value).match(
+        () => Option.none(),
+        Some.new,
+      );
 
   @override
   T? toNullable() => _value;
@@ -603,7 +609,7 @@ class None<T> extends Option<T> {
   Option<T> alt(Option<T> Function() orElse) => orElse();
 
   @override
-  B match<B>(B Function(T t) onSome, B Function() onNone) => onNone();
+  B match<B>(B Function() onNone, B Function(T t) onSome) => onNone();
 
   @override
   Option<Z> extend<Z>(Z Function(Option<T> t) f) => Option.none();

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -59,8 +59,8 @@ abstract class _OptionHKT {}
 /// /// Using [Option] you are required to specify every possible case.
 /// /// The type system helps you to find and define edge-cases and avoid errors.
 /// mStr.match(
-///   printString,
 ///   () => print('I have no string to print 🤷‍♀️'),
+///   printString,
 /// );
 /// ```
 abstract class Option<T> extends HKT<_OptionHKT, T>
@@ -295,12 +295,26 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
           E Function(T t, C c, D d) f) =>
       flatMap((a) => mc.flatMap((c) => md.map((d) => f(a, c, d))));
 
+  /// {@template fpdart_option_match}
   /// Execute `onSome` when value is [Some], otherwise execute `onNone`.
+  /// {@endtemplate}
   /// ```dart
-  /// [🍌].match((🍌) => 🍌 * 2, () => 🍎) -> 🍌🍌
-  /// [_].match((🍌) => 🍌 * 2, () => 🍎) -> 🍎
+  /// [🍌].match(() => 🍎, (🍌) => 🍌 * 2) -> 🍌🍌
+  /// [_].match(() => 🍎, (🍌) => 🍌 * 2) -> 🍎
   /// ```
+  ///
+  /// Same as `fold`.
   B match<B>(B Function() onNone, B Function(T t) onSome);
+
+  /// {@macro fpdart_option_match}
+  /// ```dart
+  /// [🍌].fold(() => 🍎, (🍌) => 🍌 * 2) -> 🍌🍌
+  /// [_].fold(() => 🍎, (🍌) => 🍌 * 2) -> 🍎
+  /// ```
+  ///
+  /// Same as `match`.
+  B fold<B>(B Function() onNone, B Function(T t) onSome) =>
+      match(onNone, onSome);
 
   /// Return `true` when value is [Some].
   bool isSome();
@@ -316,7 +330,7 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
   ///
   ///  👆 same as 👇
   ///
-  /// [🍌].match((🍌) => 🍌, () => 🍎)
+  /// [🍌].match(() => 🍎, (🍌) => 🍌)
   /// ```
   T getOrElse(T Function() orElse);
 

--- a/lib/src/task_either.dart
+++ b/lib/src/task_either.dart
@@ -192,7 +192,10 @@ class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
   /// When `option` is [Some], then return [Right] when
   /// running [TaskEither]. Otherwise return `onNone`.
   factory TaskEither.fromOption(Option<R> option, L Function() onNone) =>
-      TaskEither(() async => option.match(right, () => Left(onNone())));
+      TaskEither(() async => option.match(
+            () => Left(onNone()),
+            Right.new,
+          ));
 
   /// Build a [TaskEither] that returns `either`.
   factory TaskEither.fromEither(Either<L, R> either) =>

--- a/test/src/either_test.dart
+++ b/test/src/either_test.dart
@@ -408,7 +408,9 @@ void main() {
       test('Right', () {
         final value = Either<String, int>.of(10);
         final ap = value.toOption();
-        ap.match((some) => expect(some, 10), () => null);
+        ap.matchTestSome((t) {
+          expect(t, 10);
+        });
       });
 
       test('Left', () {
@@ -472,7 +474,9 @@ void main() {
       test('Left', () {
         final value = Either<String, int>.left('none');
         final ap = value.getLeft();
-        ap.match((some) => expect(some, 'none'), () => null);
+        ap.matchTestSome((t) {
+          expect(t, 'none');
+        });
       });
     });
 
@@ -480,7 +484,9 @@ void main() {
       test('Right', () {
         final value = Either<String, int>.of(10);
         final ap = value.getRight();
-        ap.match((some) => expect(some, 10), () => null);
+        ap.matchTestSome((t) {
+          expect(t, 10);
+        });
       });
 
       test('Left', () {

--- a/test/src/map_extension_test.dart
+++ b/test/src/map_extension_test.dart
@@ -1,5 +1,6 @@
 import 'package:fpdart/fpdart.dart';
-import 'package:test/test.dart';
+
+import './utils/utils.dart';
 
 void main() {
   group('FpdartOnMutableMap', () {
@@ -44,7 +45,9 @@ void main() {
       test('Some', () {
         final map = <String, int>{'a': 1, 'b': 2, 'c': 3, 'd': 4};
         final ap = map.lookup('b');
-        ap.match((t) => expect(t, 2), () => null);
+        ap.matchTestSome((t) {
+          expect(t, 2);
+        });
       });
 
       test('None', () {
@@ -58,10 +61,10 @@ void main() {
       test('Some', () {
         final map = <String, int>{'a': 1, 'b': 2, 'c': 3, 'd': 4};
         final ap = map.lookupWithKey('b');
-        ap.match((t) {
+        ap.matchTestSome((t) {
           expect(t.first, 'b');
           expect(t.second, 2);
-        }, () => null);
+        });
       });
 
       test('None', () {
@@ -92,8 +95,9 @@ void main() {
         final map = <String, int>{'a': 1, 'b': 2, 'c': 3, 'd': 4};
         final ap =
             map.modifyAt(Eq.instance((a1, a2) => a1 == a2))('b', (v) => v + 2);
-        ap.match((t) => t.lookup('b').match((t) => expect(t, 4), () => null),
-            () => null);
+        ap.matchTestSome((t) => t.lookup('b').matchTestSome((t) {
+              expect(t, 4);
+            }));
       });
 
       test('None', () {
@@ -109,14 +113,18 @@ void main() {
         final map = <String, int>{'a': 1, 'b': 2, 'c': 3, 'd': 4};
         final ap = map.modifyAtIfPresent(Eq.instance((a1, a2) => a1 == a2))(
             'b', (v) => v + 2);
-        ap.lookup('b').match((t) => expect(t, 4), () => null);
+        ap.lookup('b').matchTestSome((t) {
+          expect(t, 4);
+        });
       });
 
       test('not found', () {
         final map = <String, int>{'a': 1, 'b': 2, 'c': 3, 'd': 4};
         final ap = map.modifyAtIfPresent(Eq.instance((a1, a2) => a1 == a2))(
             'e', (v) => v + 2);
-        ap.lookup('b').match((t) => expect(t, 2), () => null);
+        ap.lookup('b').matchTestSome((t) {
+          expect(t, 2);
+        });
       });
     });
 
@@ -124,8 +132,9 @@ void main() {
       test('Some', () {
         final map = <String, int>{'a': 1, 'b': 2, 'c': 3, 'd': 4};
         final ap = map.updateAt(Eq.instance((a1, a2) => a1 == a2))('b', 10);
-        ap.match((t) => t.lookup('b').match((t) => expect(t, 10), () => null),
-            () => null);
+        ap.matchTestSome((t) => t.lookup('b').matchTestSome((t) {
+              expect(t, 10);
+            }));
       });
 
       test('None', () {
@@ -140,14 +149,18 @@ void main() {
         final map = <String, int>{'a': 1, 'b': 2, 'c': 3, 'd': 4};
         final ap =
             map.updateAtIfPresent(Eq.instance((a1, a2) => a1 == a2))('b', 10);
-        ap.lookup('b').match((t) => expect(t, 10), () => null);
+        ap.lookup('b').matchTestSome((t) {
+          expect(t, 10);
+        });
       });
 
       test('not found', () {
         final map = <String, int>{'a': 1, 'b': 2, 'c': 3, 'd': 4};
         final ap =
             map.updateAtIfPresent(Eq.instance((a1, a2) => a1 == a2))('e', 10);
-        ap.lookup('b').match((t) => expect(t, 2), () => null);
+        ap.lookup('b').matchTestSome((t) {
+          expect(t, 2);
+        });
       });
     });
 
@@ -165,15 +178,23 @@ void main() {
         expect(map.lookup('e'), isA<None>());
         final ap = map.upsertAt(Eq.instance((a1, a2) => a1 == a2))('e', 10);
         expect(map.lookup('e'), isA<None>());
-        ap.lookup('e').match((t) => expect(t, 10), () => null);
+        ap.lookup('e').matchTestSome((t) {
+          expect(t, 10);
+        });
       });
 
       test('update', () {
         final map = <String, int>{'a': 1, 'b': 2, 'c': 3, 'd': 4};
-        map.lookup('b').match((t) => expect(t, 2), () => null);
+        map.lookup('b').matchTestSome((t) {
+          expect(t, 2);
+        });
         final ap = map.upsertAt(Eq.instance((a1, a2) => a1 == a2))('b', 10);
-        map.lookup('b').match((t) => expect(t, 2), () => null);
-        ap.lookup('b').match((t) => expect(t, 10), () => null);
+        map.lookup('b').matchTestSome((t) {
+          expect(t, 2);
+        });
+        ap.lookup('b').matchTestSome((t) {
+          expect(t, 10);
+        });
       });
 
       test('modify by eq date year', () {
@@ -185,7 +206,9 @@ void main() {
 
         expect(map.lookup(d1), isA<None>());
         expect(map.lookup(d2), isA<Some>());
-        map.lookup(d2).match((t) => expect(t, 2), () => null);
+        map.lookup(d2).matchTestSome((t) {
+          expect(t, 2);
+        });
       });
     });
 
@@ -194,10 +217,10 @@ void main() {
         final map = <String, int>{'a': 1, 'b': 2, 'c': 3, 'd': 4};
         final ap = map.pop(Eq.instance((a1, a2) => a1 == a2))('b');
         expect(map.lookup('b'), isA<Some>());
-        ap.match((t) {
+        ap.matchTestSome((t) {
           expect(t.first, 2);
           expect(t.second.lookup('b'), isA<None>());
-        }, () => null);
+        });
       });
 
       test('None', () {

--- a/test/src/option_test.dart
+++ b/test/src/option_test.dart
@@ -551,6 +551,13 @@ void main() {
       expect(m2.match(() => 'none', (some) => 'some'), 'none');
     });
 
+    test('match', () {
+      final m1 = Option.of(10);
+      final m2 = Option<int>.none();
+      expect(m1.fold(() => 'none', (some) => 'some'), 'some');
+      expect(m2.fold(() => 'none', (some) => 'some'), 'none');
+    });
+
     test('elem', () {
       final m1 = Option.of(10);
       final m2 = Option<int>.none();

--- a/test/src/option_test.dart
+++ b/test/src/option_test.dart
@@ -18,13 +18,13 @@ void main() {
                 (option, value) {
           final r = option.map((n) => n + value);
           option.match(
+            () {
+              expect(option, r);
+            },
             (val1) {
               r.matchTestSome((val2) {
                 expect(val2, val1 + value);
               });
-            },
-            () {
-              expect(option, r);
             },
           );
         });
@@ -77,21 +77,21 @@ void main() {
     test('map', () {
       final option = Option.of(10);
       final map = option.map((a) => a + 1);
-      map.match((some) => expect(some, 11), () => null);
+      map.matchTestSome((some) => expect(some, 11));
     });
 
     test('map2', () {
       final option = Option.of(10);
       final map =
           option.map2<String, int>(Option.of('abc'), (a, b) => a + b.length);
-      map.match((some) => expect(some, 13), () => null);
+      map.matchTestSome((some) => expect(some, 13));
     });
 
     test('map3', () {
       final option = Option.of(10);
       final map = option.map3<String, double, double>(
           Option.of('abc'), Option.of(2.0), (a, b, c) => (a + b.length) / c);
-      map.match((some) => expect(some, 6.5), () => null);
+      map.matchTestSome((some) => expect(some, 6.5));
     });
 
     test('foldRight', () {
@@ -129,7 +129,7 @@ void main() {
       test('Some', () {
         final option = Option.of(10);
         final pure = option.ap(Option.of((int i) => i + 1));
-        pure.match((some) => expect(some, 11), () => null);
+        pure.matchTestSome((some) => expect(some, 11));
       });
 
       test('Some (curried)', () {
@@ -140,7 +140,7 @@ void main() {
             .ap(
               Option.of((f) => f(5)),
             );
-        ap.match((some) => expect(some, 8), () => null);
+        ap.matchTestSome((some) => expect(some, 8));
       });
 
       test('None', () {
@@ -154,7 +154,7 @@ void main() {
       test('Some', () {
         final option = Option.of(10);
         final flatMap = option.flatMap<int>((a) => Option.of(a + 1));
-        flatMap.match((some) => expect(some, 11), () => null);
+        flatMap.matchTestSome((some) => expect(some, 11));
       });
 
       test('None', () {
@@ -182,13 +182,13 @@ void main() {
       test('Some', () {
         final option = Option.of(10);
         final value = option.alt(() => Option.of(0));
-        value.match((some) => expect(some, 10), () => null);
+        value.matchTestSome((some) => expect(some, 10));
       });
 
       test('None', () {
         final option = Option<int>.none();
         final value = option.alt(() => Option.of(0));
-        value.match((some) => expect(some, 0), () => null);
+        value.matchTestSome((some) => expect(some, 0));
       });
     });
 
@@ -196,13 +196,13 @@ void main() {
       test('Some', () {
         final option = Option.of(10);
         final value = option.extend((t) => t.isSome() ? 'valid' : 'invalid');
-        value.match((some) => expect(some, 'valid'), () => null);
+        value.matchTestSome((some) => expect(some, 'valid'));
       });
 
       test('None', () {
         final option = Option<int>.none();
         final value = option.extend((t) => t.isSome() ? 'valid' : 'invalid');
-        value.match((some) => expect(some, 'invalid'), () => null);
+        expect(value, isA<None>());
       });
     });
 
@@ -210,7 +210,7 @@ void main() {
       test('Some', () {
         final option = Option.of(10);
         final value = option.duplicate();
-        value.match((some) => expect(some, isA<Some>()), () => null);
+        value.matchTestSome((some) => expect(some, isA<Some>()));
       });
 
       test('None', () {
@@ -224,7 +224,7 @@ void main() {
       test('Some (true)', () {
         final option = Option.of(10);
         final value = option.filter((a) => a > 5);
-        value.match((some) => expect(some, 10), () => null);
+        value.matchTestSome((some) => expect(some, 10));
       });
 
       test('Some (false)', () {
@@ -244,7 +244,7 @@ void main() {
       test('Some', () {
         final option = Option.of(10);
         final value = option.filterMap<String>((a) => Option.of('$a'));
-        value.match((some) => expect(some, '10'), () => null);
+        value.matchTestSome((some) => expect(some, '10'));
       });
 
       test('None', () {
@@ -259,13 +259,13 @@ void main() {
         final option = Option.of(10);
         final value = option.partition((a) => a > 5);
         expect(value.first, isA<None>());
-        value.second.match((some) => expect(some, 10), () => null);
+        value.second.matchTestSome((some) => expect(some, 10));
       });
 
       test('Some (false)', () {
         final option = Option.of(10);
         final value = option.partition((a) => a < 5);
-        value.first.match((some) => expect(some, 10), () => null);
+        value.first.matchTestSome((some) => expect(some, 10));
         expect(value.second, isA<None>());
       });
 
@@ -283,14 +283,14 @@ void main() {
         final value =
             option.partitionMap<String, double>((a) => Either.of(a / 2));
         expect(value.first, isA<None>());
-        value.second.match((some) => expect(some, 5.0), () => null);
+        value.second.matchTestSome((some) => expect(some, 5.0));
       });
 
       test('Some (left)', () {
         final option = Option.of(10);
         final value =
             option.partitionMap<String, double>((a) => Either.left('$a'));
-        value.first.match((some) => expect(some, '10'), () => null);
+        value.first.matchTestSome((some) => expect(some, '10'));
         expect(value.second, isA<None>());
       });
 
@@ -306,7 +306,7 @@ void main() {
     group('fromEither', () {
       test('Right', () {
         final option = Option.fromEither<String, int>(Either.of(10));
-        option.match((some) => expect(some, 10), () => null);
+        option.matchTestSome((some) => expect(some, 10));
       });
 
       test('Left', () {
@@ -318,7 +318,7 @@ void main() {
     group('fromPredicate', () {
       test('Some', () {
         final option = Option<int>.fromPredicate(10, (a) => a > 5);
-        option.match((some) => expect(some, 10), () => null);
+        option.matchTestSome((some) => expect(some, 10));
       });
 
       test('None', () {
@@ -331,7 +331,7 @@ void main() {
       test('Some', () {
         final option =
             Option.fromPredicateMap<int, String>(10, (a) => a > 5, (a) => '$a');
-        option.match((some) => expect(some, '10'), () => null);
+        option.matchTestSome((some) => expect(some, '10'));
       });
 
       test('None', () {
@@ -344,7 +344,7 @@ void main() {
     group('flatten', () {
       test('Right', () {
         final option = Option.flatten(Option.of(Option.of(10)));
-        option.match((some) => expect(some, 10), () => null);
+        option.matchTestSome((some) => expect(some, 10));
       });
 
       test('Left', () {
@@ -357,13 +357,13 @@ void main() {
       test('Right', () {
         final option = Option.separate<String, int>(Option.of(Either.of(10)));
         expect(option.first, isA<None>());
-        option.second.match((some) => expect(some, 10), () => null);
+        option.second.matchTestSome((some) => expect(some, 10));
       });
 
       test('Left', () {
         final option =
             Option.separate<String, int>(Option.of(Either.left('none')));
-        option.first.match((some) => expect(some, 'none'), () => null);
+        option.first.matchTestSome((some) => expect(some, 'none'));
         expect(option.second, isA<None>());
       });
     });
@@ -375,7 +375,7 @@ void main() {
 
     test('of', () {
       final option = Option.of(10);
-      option.match((some) => expect(some, 10), () => null);
+      option.matchTestSome((some) => expect(some, 10));
     });
 
     test('isSome', () {
@@ -450,8 +450,8 @@ void main() {
     test('pure', () {
       final m1 = Option.of(10);
       final m2 = Option<int>.none();
-      m1.pure('abc').match((some) => expect(some, 'abc'), () => null);
-      m2.pure('abc').match((some) => expect(some, 'abc'), () => null);
+      m1.pure('abc').matchTestSome((some) => expect(some, 'abc'));
+      m2.pure('abc').matchTestSome((some) => expect(some, 'abc'));
     });
 
     test('length', () {
@@ -512,43 +512,43 @@ void main() {
       final m2 = Option<int>.none();
       m1
           .andThen(() => Option.of('abc'))
-          .match((some) => expect(some, 'abc'), () => null);
+          .matchTestSome((some) => expect(some, 'abc'));
       expect(m2.andThen(() => Option.of('abc')), isA<None>());
     });
 
     test('call', () {
       final m1 = Option.of(10);
       final m2 = Option<int>.none();
-      m1(Option.of('abc')).match((some) => expect(some, 'abc'), () => null);
-      m2(Option.of('abc')).match((some) => expect(some, 'abc'), () => null);
+      m1(Option.of('abc')).matchTestSome((some) => expect(some, 'abc'));
+      expect(m2(Option.of('abc')), isA<None>());
     });
 
     test('plus', () {
       final m1 = Option.of(10);
       final m2 = Option<int>.none();
-      m1.plus(Option.of(0)).match((some) => expect(some, 10), () => null);
-      m2.plus(Option.of(0)).match((some) => expect(some, 0), () => null);
+      m1.plus(Option.of(0)).matchTestSome((some) => expect(some, 10));
+      m2.plus(Option.of(0)).matchTestSome((some) => expect(some, 0));
     });
 
     test('prepend', () {
       final m1 = Option.of(10);
       final m2 = Option<int>.none();
-      m1.prepend(0).match((some) => expect(some, 0), () => null);
-      m2.prepend(0).match((some) => expect(some, 0), () => null);
+      m1.prepend(0).matchTestSome((some) => expect(some, 0));
+      m2.prepend(0).matchTestSome((some) => expect(some, 0));
     });
 
     test('append', () {
       final m1 = Option.of(10);
       final m2 = Option<int>.none();
-      m1.append(0).match((some) => expect(some, 10), () => null);
-      m2.append(0).match((some) => expect(some, 0), () => null);
+      m1.append(0).matchTestSome((some) => expect(some, 10));
+      m2.append(0).matchTestSome((some) => expect(some, 0));
     });
 
     test('match', () {
       final m1 = Option.of(10);
       final m2 = Option<int>.none();
-      expect(m1.match((some) => 'some', () => 'none'), 'some');
-      expect(m2.match((some) => 'some', () => 'none'), 'none');
+      expect(m1.match(() => 'none', (some) => 'some'), 'some');
+      expect(m2.match(() => 'none', (some) => 'some'), 'none');
     });
 
     test('elem', () {
@@ -575,10 +575,10 @@ void main() {
       expect(m.empty, isA<None<int>>());
       m
           .combine(Option.of(10), Option.of(0))
-          .match((some) => expect(some, 10), () => null);
+          .matchTestSome((some) => expect(some, 10));
       m
           .combine(Option.none(), Option.of(0))
-          .match((some) => expect(some, 0), () => null);
+          .matchTestSome((some) => expect(some, 0));
     });
 
     test('getLastMonoid', () {
@@ -586,10 +586,10 @@ void main() {
       expect(m.empty, isA<None<int>>());
       m
           .combine(Option.of(10), Option.of(0))
-          .match((some) => expect(some, 0), () => null);
+          .matchTestSome((some) => expect(some, 0));
       m
           .combine(Option.of(10), Option.none())
-          .match((some) => expect(some, 10), () => null);
+          .matchTestSome((some) => expect(some, 10));
     });
 
     test('getMonoid', () {
@@ -597,7 +597,7 @@ void main() {
       expect(m.empty, isA<None<int>>());
       m
           .combine(Option.of(10), Option.of(20))
-          .match((some) => expect(some, 30), () => null);
+          .matchTestSome((some) => expect(some, 30));
       expect(m.combine(Option.of(10), Option.none()), isA<None<int>>());
       expect(m.combine(Option.none(), Option.of(10)), isA<None<int>>());
     });

--- a/test/src/task_option_test.dart
+++ b/test/src/task_option_test.dart
@@ -8,7 +8,7 @@ void main() {
       test('Success', () async {
         final task = TaskOption<int>.tryCatch(() => Future.value(10));
         final r = await task.run();
-        r.match((r) => expect(r, 10), () => null);
+        r.matchTestSome((r) => expect(r, 10));
       });
 
       test('Failure', () async {
@@ -33,7 +33,7 @@ void main() {
           (n) => Future.value(n + 5),
         ));
         final r = await ap.run();
-        r.match((r) => expect(r, 15), () => null);
+        r.matchTestSome((r) => expect(r, 15));
       });
 
       test('Failure', () async {
@@ -61,7 +61,7 @@ void main() {
         final ap =
             task.flatMap((r) => TaskOption<int>(() async => Option.of(r + 10)));
         final r = await ap.run();
-        r.match((r) => expect(r, 20), () => null);
+        r.matchTestSome((r) => expect(r, 20));
       });
 
       test('None', () async {
@@ -79,7 +79,7 @@ void main() {
         final ap = task
             .ap<double>(TaskOption(() async => Option.of((int c) => c / 2)));
         final r = await ap.run();
-        r.match((r) => expect(r, 5.0), () => null);
+        r.matchTestSome((r) => expect(r, 5.0));
       });
 
       test('None', () async {
@@ -96,7 +96,7 @@ void main() {
         final task = TaskOption<int>(() async => Option.of(10));
         final ap = task.map((r) => r / 2);
         final r = await ap.run();
-        r.match((r) => expect(r, 5.0), () => null);
+        r.matchTestSome((r) => expect(r, 5.0));
       });
 
       test('None', () async {
@@ -113,7 +113,7 @@ void main() {
         final ap = task.map2<int, double>(
             TaskOption<int>(() async => Option.of(2)), (b, c) => b / c);
         final r = await ap.run();
-        r.match((r) => expect(r, 5.0), () => null);
+        r.matchTestSome((r) => expect(r, 5.0));
       });
 
       test('None', () async {
@@ -133,7 +133,7 @@ void main() {
             TaskOption<int>(() async => Option.of(5)),
             (b, c, d) => b * c / d);
         final r = await ap.run();
-        r.match((r) => expect(r, 4.0), () => null);
+        r.matchTestSome((r) => expect(r, 4.0));
       });
 
       test('None', () async {
@@ -153,7 +153,7 @@ void main() {
         final ap =
             task.andThen(() => TaskOption<double>(() async => Option.of(12.5)));
         final r = await ap.run();
-        r.match((r) => expect(r, 12.5), () => null);
+        r.matchTestSome((r) => expect(r, 12.5));
       });
 
       test('None', () async {
@@ -170,14 +170,14 @@ void main() {
         final task = TaskOption<int>(() async => Option.of(10));
         final ap = task(TaskOption<double>(() async => Option.of(12.5)));
         final r = await ap.run();
-        r.match((r) => expect(r, 12.5), () => null);
+        r.matchTestSome((r) => expect(r, 12.5));
       });
 
       test('None', () async {
         final task = TaskOption<int>(() async => Option.none());
         final ap = task(TaskOption<double>(() async => Option.of(12.5)));
         final r = await ap.run();
-        r.match((r) => expect(r, 12.5), () => null);
+        expect(r, isA<None>());
       });
     });
 
@@ -185,7 +185,7 @@ void main() {
       final task = TaskOption<int>(() async => Option.none());
       final ap = task.pure('abc');
       final r = await ap.run();
-      r.match((r) => expect(r, 'abc'), () => null);
+      r.matchTestSome((r) => expect(r, 'abc'));
     });
 
     test('run', () async {
@@ -193,14 +193,14 @@ void main() {
       final future = task.run();
       expect(future, isA<Future>());
       final r = await future;
-      r.match((r) => expect(r, 10), () => null);
+      r.matchTestSome((r) => expect(r, 10));
     });
 
     group('fromEither', () {
       test('Some', () async {
         final task = TaskOption.fromEither<String, int>(Either.of(10));
         final r = await task.run();
-        r.match((r) => expect(r, 10), () => null);
+        r.matchTestSome((r) => expect(r, 10));
       });
 
       test('None', () async {
@@ -214,7 +214,7 @@ void main() {
       test('True', () async {
         final task = TaskOption<int>.fromPredicate(20, (n) => n > 10);
         final r = await task.run();
-        r.match((r) => expect(r, 20), () => null);
+        r.matchTestSome((r) => expect(r, 20));
       });
 
       test('False', () async {
@@ -227,7 +227,7 @@ void main() {
     test('fromTask', () async {
       final task = TaskOption<int>.fromTask(Task(() async => 10));
       final r = await task.run();
-      r.match((r) => expect(r, 10), () => null);
+      r.matchTestSome((r) => expect(r, 10));
     });
 
     test('none()', () async {
@@ -239,7 +239,7 @@ void main() {
     test('some()', () async {
       final task = TaskOption<int>.some(10);
       final r = await task.run();
-      r.match((r) => expect(r, 10), () => null);
+      r.matchTestSome((r) => expect(r, 10));
     });
 
     group('match', () {
@@ -280,7 +280,7 @@ void main() {
         final ex =
             task.orElse<int>(() => TaskOption(() async => Option.of(-1)));
         final r = await ex.run();
-        r.match((r) => expect(r, 10), () => null);
+        r.matchTestSome((r) => expect(r, 10));
       });
 
       test('None', () async {
@@ -288,7 +288,7 @@ void main() {
         final ex =
             task.orElse<int>(() => TaskOption(() async => Option.of(-1)));
         final r = await ex.run();
-        r.match((r) => expect(r, -1), () => null);
+        r.matchTestSome((r) => expect(r, -1));
       });
     });
 
@@ -297,28 +297,28 @@ void main() {
         final task = TaskOption<int>(() async => Option.of(10));
         final ex = task.alt(() => TaskOption(() async => Option.of(20)));
         final r = await ex.run();
-        r.match((r) => expect(r, 10), () => null);
+        r.matchTestSome((r) => expect(r, 10));
       });
 
       test('None', () async {
         final task = TaskOption<int>(() async => Option.none());
         final ex = task.alt(() => TaskOption(() async => Option.of(20)));
         final r = await ex.run();
-        r.match((r) => expect(r, 20), () => null);
+        r.matchTestSome((r) => expect(r, 20));
       });
     });
 
     test('of', () async {
       final task = TaskOption<int>.of(10);
       final r = await task.run();
-      r.match((r) => expect(r, 10), () => null);
+      r.matchTestSome((r) => expect(r, 10));
     });
 
     test('flatten', () async {
       final task = TaskOption<TaskOption<int>>.of(TaskOption<int>.of(10));
       final ap = TaskOption.flatten(task);
       final r = await ap.run();
-      r.match((r) => expect(r, 10), () => null);
+      r.matchTestSome((r) => expect(r, 10));
     });
 
     test('delay', () async {

--- a/test/src/utils/match_utils.dart
+++ b/test/src/utils/match_utils.dart
@@ -3,9 +3,9 @@ import 'package:test/test.dart';
 
 extension OptionMatch<T> on Option<T> {
   /// Run test on [Some], call `fail` if [None].
-  void matchTestSome(void Function(T t) testing) => match(testing, () {
+  void matchTestSome(void Function(T t) testing) => match(() {
         fail("should be some, found none");
-      });
+      }, testing);
 }
 
 extension EitherMatch<L, R> on Either<L, R> {


### PR DESCRIPTION
>  ⚠️: **Breaking change**

This PR inverts the `onNone` and `onSome` in the `match` method of the `Option` type.

As mentioned in #52, having the `Some` case first and the `None` (error) case second was not intuitive. This changes also aligns `Option` with `Either`, where the error (`Left`) is expected first and the success (`Right`) second.

Furthermore, this PR also adds the `fold` method to `Option`, equivalent to `match` (in order to align `Option` to `Either`).

```dart
/// Previously
final match = option.match(
  (a) => print('Some($a)'),
  () => print('None'), // <- `None` second 👎 
);

/// New
final match = option.match(
  () => print('None'), // <- `None` first 👍
  (a) => print('Some($a)'),
);
// or
final match = option.fold(
  () => print('None'),
  (a) => print('Some($a)'),
);
```