### PR TITLE
`lefts` / `rights` / `partitionEithers` / `bimap` methods

### DIFF
--- a/lib/src/either.dart
+++ b/lib/src/either.dart
@@ -293,6 +293,36 @@ abstract class Either<L, R> extends HKT2<_EitherHKT, L, R>
   ) =>
       traverseList(list, identity);
 
+  /// {@template fpdart_rights_either}
+  /// Extract all the [Right] values from a `List<Either<E, A>>`.
+  /// {@endtemplate}
+  static List<A> rights<E, A>(List<Either<E, A>> list) {
+    final resultList = <A>[];
+    for (var i = 0; i < list.length; i++) {
+      final e = list[i];
+      if (e is Right<E, A>) {
+        resultList.add(e._value);
+      }
+    }
+
+    return resultList;
+  }
+
+  /// {@template fpdart_lefts_either}
+  /// Extract all the [Left] values from a `List<Either<E, A>>`.
+  /// {@endtemplate}
+  static List<E> lefts<E, A>(List<Either<E, A>> list) {
+    final resultList = <E>[];
+    for (var i = 0; i < list.length; i++) {
+      final e = list[i];
+      if (e is Left<E, A>) {
+        resultList.add(e._value);
+      }
+    }
+
+    return resultList;
+  }
+
   /// Flat a [Either] contained inside another [Either] to be a single [Either].
   factory Either.flatten(Either<L, Either<L, R>> e) => e.flatMap(identity);
 

--- a/lib/src/either.dart
+++ b/lib/src/either.dart
@@ -333,6 +333,30 @@ abstract class Either<L, R> extends HKT2<_EitherHKT, L, R>
     return resultList;
   }
 
+  /// {@template fpdart_partition_eithers_either}
+  /// Extract all the [Left] and [Right] values from a `List<Either<E, A>>` and
+  /// return them in two partitioned [List] inside [Tuple2].
+  /// {@endtemplate}
+  static Tuple2<List<E>, List<A>> partitionEithers<E, A>(
+      List<Either<E, A>> list) {
+    final resultListLefts = <E>[];
+    final resultListRights = <A>[];
+    for (var i = 0; i < list.length; i++) {
+      final e = list[i];
+      if (e is Left<E, A>) {
+        resultListLefts.add(e._value);
+      } else if (e is Right<E, A>) {
+        resultListRights.add(e._value);
+      } else {
+        throw Exception(
+          "[fpdart]: Error when mapping Either, it should be either Left or Right.",
+        );
+      }
+    }
+
+    return Tuple2(resultListLefts, resultListRights);
+  }
+
   /// Flat a [Either] contained inside another [Either] to be a single [Either].
   factory Either.flatten(Either<L, Either<L, R>> e) => e.flatMap(identity);
 

--- a/lib/src/either.dart
+++ b/lib/src/either.dart
@@ -90,6 +90,16 @@ abstract class Either<L, R> extends HKT2<_EitherHKT, L, R>
   @override
   Either<L, C> map<C>(C Function(R a) f);
 
+  /// Define two functions to change both the [Left] and [Right] value of the
+  /// [Either].
+  ///
+  /// {@template fpdart_bimap_either}
+  /// Same as `map`+`mapLeft` but for both [Left] and [Right]
+  /// (`map` is only to change [Right], while `mapLeft` is only to change [Left]).
+  /// {@endtemplate}
+  Either<C, D> bimap<C, D>(C Function(L l) mLeft, D Function(R b) mRight) =>
+      mapLeft(mLeft).map(mRight);
+
   /// Return a [Right] containing the value `c`.
   @override
   Either<L, C> pure<C>(C c) => Right<L, C>(c);

--- a/lib/src/io_either.dart
+++ b/lib/src/io_either.dart
@@ -90,6 +90,18 @@ class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
   @override
   IOEither<L, C> map<C>(C Function(R r) f) => ap(pure(f));
 
+  /// Change the value in the [Left] of [IOEither].
+  IOEither<C, R> mapLeft<C>(C Function(L l) f) => IOEither(
+        () => (run()).match((l) => Either.left(f(l)), Either.of),
+      );
+
+  /// Define two functions to change both the [Left] and [Right] value of the
+  /// [IOEither].
+  ///
+  /// {@macro fpdart_bimap_either}
+  IOEither<C, D> bimap<C, D>(C Function(L a) mLeft, D Function(R b) mRight) =>
+      mapLeft(mLeft).map(mRight);
+
   /// Apply the function contained inside `a` to change the value on the [Right] from
   /// type `R` to a value of type `C`.
   @override

--- a/lib/src/list_extension.dart
+++ b/lib/src/list_extension.dart
@@ -505,6 +505,12 @@ extension FpdartSequenceIterableTask<T> on Iterable<Task<T>> {
 extension FpdartSequenceIterableEither<E, T> on Iterable<Either<E, T>> {
   /// {@macro fpdart_sequence__io}
   Either<E, List<T>> sequenceEither() => Either.sequenceList(toList());
+
+  /// {@macro fpdart_rights_either}
+  List<T> rightsEither() => Either.rights(toList());
+
+  /// {@macro fpdart_lefts_either}
+  List<E> leftsEither() => Either.lefts(toList());
 }
 
 extension FpdartSequenceIterableTaskEither<E, T> on Iterable<TaskEither<E, T>> {

--- a/lib/src/list_extension.dart
+++ b/lib/src/list_extension.dart
@@ -502,15 +502,19 @@ extension FpdartSequenceIterableTask<T> on Iterable<Task<T>> {
   Task<List<T>> sequenceTaskSeq() => Task.sequenceListSeq(toList());
 }
 
-extension FpdartSequenceIterableEither<E, T> on Iterable<Either<E, T>> {
-  /// {@macro fpdart_sequence__io}
-  Either<E, List<T>> sequenceEither() => Either.sequenceList(toList());
+extension FpdartSequenceIterableEither<E, A> on Iterable<Either<E, A>> {
+  /// {@macro fpdart_sequence_list_either}
+  Either<E, List<A>> sequenceEither() => Either.sequenceList(toList());
 
   /// {@macro fpdart_rights_either}
-  List<T> rightsEither() => Either.rights(toList());
+  List<A> rightsEither() => Either.rights(toList());
 
   /// {@macro fpdart_lefts_either}
   List<E> leftsEither() => Either.lefts(toList());
+
+  /// {@macro fpdart_partition_eithers_either}
+  Tuple2<List<E>, List<A>> partitionEithersEither() =>
+      Either.partitionEithers(toList());
 }
 
 extension FpdartSequenceIterableTaskEither<E, T> on Iterable<TaskEither<E, T>> {

--- a/lib/src/task_either.dart
+++ b/lib/src/task_either.dart
@@ -71,17 +71,16 @@ class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
   TaskEither<L, C> map<C>(C Function(R r) f) => ap(pure(f));
 
   /// Change the value in the [Left] of [TaskEither].
-  TaskEither<C, R> mapLeft<C>(C Function(L l) f) => TaskEither(() async =>
-      (await run()).match((l) => Either.left(f(l)), (r) => Either.of(r)));
+  TaskEither<C, R> mapLeft<C>(C Function(L l) f) => TaskEither(
+        () async => (await run()).match((l) => Either.left(f(l)), Either.of),
+      );
 
   /// Define two functions to change both the [Left] and [Right] value of the
   /// [TaskEither].
   ///
-  /// Same as `map`+`mapLeft` but for both [Left] and [Right]
-  /// (`map` is only to change [Right], while `mapLeft` is only to change [Left]).
-  TaskEither<C, D> bimap<C, D>(
-          C Function(L l) mapLeft, D Function(R r) mapRight) =>
-      map(mapRight).mapLeft(mapLeft);
+  /// {@macro fpdart_bimap_either}
+  TaskEither<C, D> bimap<C, D>(C Function(L l) mLeft, D Function(R r) mRight) =>
+      mapLeft(mLeft).map(mRight);
 
   /// Apply the function contained inside `a` to change the value on the [Right] from
   /// type `R` to a value of type `C`.

--- a/lib/src/tuple.dart
+++ b/lib/src/tuple.dart
@@ -60,6 +60,14 @@ class Tuple2<T1, T2> extends HKT2<_Tuple2HKT, T1, T2>
   @override
   Tuple2<T1, C> map<C>(C Function(T2 a) f) => mapSecond(f);
 
+  /// Change type of both values of the [Tuple].
+  ///
+  /// This is the same as `mapFirst` followed by `mapSecond`.
+  ///
+  /// Same as `mapBoth` but using two distinct functions instead of just one.
+  Tuple2<C, D> bimap<C, D>(C Function(T1 a) mFirst, D Function(T2 b) mSecond) =>
+      mapFirst(mFirst).mapSecond(mSecond);
+
   /// Convert the second value of the [Tuple2] from `T2` to `Z` using `f`.
   @override
   Tuple2<T1, Z> extend<Z>(Z Function(Tuple2<T1, T2> t) f) =>

--- a/lib/src/typeclass/functor.dart
+++ b/lib/src/typeclass/functor.dart
@@ -9,5 +9,5 @@ mixin Functor<G, A> on HKT<G, A> {
 }
 
 mixin Functor2<G, A, B> on HKT2<G, A, B> {
-  HKT2<G, A, C> map<C>(C Function(B a) f);
+  HKT2<G, A, C> map<C>(C Function(B b) f);
 }

--- a/test/src/either_test.dart
+++ b/test/src/either_test.dart
@@ -1047,4 +1047,17 @@ void main() {
     final result = Either.lefts(list);
     expect(result, ['a', 'b']);
   });
+
+  test('partitionEithers', () {
+    final list = [
+      right<String, int>(1),
+      right<String, int>(2),
+      left<String, int>('a'),
+      left<String, int>('b'),
+      right<String, int>(3),
+    ];
+    final result = Either.partitionEithers(list);
+    expect(result.first, ['a', 'b']);
+    expect(result.second, [1, 2, 3]);
+  });
 }

--- a/test/src/either_test.dart
+++ b/test/src/either_test.dart
@@ -50,6 +50,22 @@ void main() {
       });
     });
 
+    group('bimap', () {
+      test('Right', () {
+        final value = Either<String, int>.of(10);
+        final map = value.bimap((l) => "none", (a) => a + 1);
+        map.matchTestRight((r) {
+          expect(r, 11);
+        });
+      });
+
+      test('Left', () {
+        final value = Either<String, int>.left('abc');
+        final map = value.bimap((l) => "none", (a) => a + 1);
+        map.matchTestLeft((l) => expect(l, 'none'));
+      });
+    });
+
     group('map2', () {
       test('Right', () {
         final value = Either<String, int>.of(10);

--- a/test/src/either_test.dart
+++ b/test/src/either_test.dart
@@ -1007,4 +1007,28 @@ void main() {
       },
     );
   });
+
+  test('rights', () {
+    final list = [
+      right<String, int>(1),
+      right<String, int>(2),
+      left<String, int>('a'),
+      left<String, int>('b'),
+      right<String, int>(3),
+    ];
+    final result = Either.rights(list);
+    expect(result, [1, 2, 3]);
+  });
+
+  test('lefts', () {
+    final list = [
+      right<String, int>(1),
+      right<String, int>(2),
+      left<String, int>('a'),
+      left<String, int>('b'),
+      right<String, int>(3),
+    ];
+    final result = Either.lefts(list);
+    expect(result, ['a', 'b']);
+  });
 }

--- a/test/src/io_either_test.dart
+++ b/test/src/io_either_test.dart
@@ -160,6 +160,38 @@ void main() {
       });
     });
 
+    group('mapLeft', () {
+      test('Right', () {
+        final task = IOEither<String, int>(() => Either.of(10));
+        final ap = task.mapLeft((l) => l.length);
+        final r = ap.run();
+        r.matchTestRight((r) => expect(r, 10));
+      });
+
+      test('Left', () {
+        final task = IOEither<String, int>(() => Either.left('abc'));
+        final ap = task.mapLeft((l) => l.length);
+        final r = ap.run();
+        r.matchTestLeft((l) => expect(l, 3));
+      });
+    });
+
+    group('bimap', () {
+      test('Right', () {
+        final task = IOEither<String, int>(() => Either.of(10));
+        final ap = task.bimap((l) => l.length, (r) => r / 2);
+        final r = ap.run();
+        r.matchTestRight((r) => expect(r, 5.0));
+      });
+
+      test('Left', () {
+        final task = IOEither<String, int>(() => Either.left('abc'));
+        final ap = task.bimap((l) => l.length, (r) => r / 2);
+        final r = ap.run();
+        r.matchTestLeft((l) => expect(l, 3));
+      });
+    });
+
     group('map2', () {
       test('Right', () {
         final task = IOEither<String, int>(() => Either.of(10));

--- a/test/src/list_extension_test.dart
+++ b/test/src/list_extension_test.dart
@@ -1236,6 +1236,30 @@ void main() {
         });
       });
     });
+
+    test('rightsEither', () {
+      final list = [
+        right<String, int>(1),
+        right<String, int>(2),
+        left<String, int>('a'),
+        left<String, int>('b'),
+        right<String, int>(3),
+      ];
+      final result = list.rightsEither();
+      expect(result, [1, 2, 3]);
+    });
+
+    test('leftsEither', () {
+      final list = [
+        right<String, int>(1),
+        right<String, int>(2),
+        left<String, int>('a'),
+        left<String, int>('b'),
+        right<String, int>(3),
+      ];
+      final result = list.leftsEither();
+      expect(result, ['a', 'b']);
+    });
   });
 
   group('FpdartSequenceIterableTaskOption', () {

--- a/test/src/list_extension_test.dart
+++ b/test/src/list_extension_test.dart
@@ -1260,6 +1260,19 @@ void main() {
       final result = list.leftsEither();
       expect(result, ['a', 'b']);
     });
+
+    test('partitionEithersEither', () {
+      final list = [
+        right<String, int>(1),
+        right<String, int>(2),
+        left<String, int>('a'),
+        left<String, int>('b'),
+        right<String, int>(3),
+      ];
+      final result = list.partitionEithersEither();
+      expect(result.first, ['a', 'b']);
+      expect(result.second, [1, 2, 3]);
+    });
   });
 
   group('FpdartSequenceIterableTaskOption', () {

--- a/test/src/tuple_test.dart
+++ b/test/src/tuple_test.dart
@@ -39,6 +39,13 @@ void main() {
       expect(map.second, '10');
     });
 
+    test('bimap', () {
+      const tuple = Tuple2('abc', 10);
+      final map = tuple.bimap((v1) => v1.length, (v2) => '$v2');
+      expect(map.first, 3);
+      expect(map.second, '10');
+    });
+
     test('apply', () {
       const tuple = Tuple2('abc', 10);
       final ap = tuple.apply((v1, v2) => v1.length + v2);


### PR DESCRIPTION
## `lefts`, `rights`, `partitionEithers`
This PR adds the `lefts`, `rights`, and `partitionEithers` methods to `Either`.

As for #48, previously it was hard to filter all the `Right` or `Left` values from a `List` of `Either`.

`lefts` and `rights` allows to extract only `Right` and `Left` values from an `Either` (same as their respective Haskell methods [`lefts`](https://hackage.haskell.org/package/base-4.17.0.0/docs/Data-Either.html#v:lefts) and [`rights`](https://hackage.haskell.org/package/base-4.17.0.0/docs/Data-Either.html#v:rights)).

`partitionEithers` extracts both `Left` and `Right` values and collects them in a `Tuple2` ([`partitionEithers`](https://hackage.haskell.org/package/base-4.17.0.0/docs/Data-Either.html#v:partitionEithers)).

Also added extension methods to `List`. 

```dart
final list = [
  right<String, int>(1),
  right<String, int>(2),
  left<String, int>('a'),
  left<String, int>('b'),
  right<String, int>(3),
];
final result = Either.rights(list);
expect(result, [1, 2, 3]); // <- All `Right` values
```

```dart
final list = [
  right<String, int>(1),
  right<String, int>(2),
  left<String, int>('a'),
  left<String, int>('b'),
  right<String, int>(3),
];
final result = Either.lefts(list);
expect(result, ['a', 'b']); // <- All `Left` values
```

## `bimap`
The `bimap` method was present in `TaskEither`, but missing in `Either`, `IOEither`, and `Tuple2`. Not anymore! Also added `mapLeft` to `IOEither`.