### PR TITLE
Make `Option.of` and `Option.none` factories const

### DIFF
--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -172,7 +172,7 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
   /// ```
   @override
   Option<B> ap<B>(covariant Option<B Function(T t)> a) => a.match(
-        () => const Option.none(),
+        () => Option<B>.none(),
         (f) => map(f),
       );
 
@@ -651,8 +651,7 @@ class None<T> extends Option<T> {
   B foldRight<B>(B b, B Function(B acc, T t) f) => b;
 
   @override
-  Option<B> flatMap<B>(covariant Option<B> Function(T t) f) =>
-      const Option.none();
+  Option<B> flatMap<B>(covariant Option<B> Function(T t) f) => Option<B>.none();
 
   @override
   T getOrElse(T Function() orElse) => orElse();

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -172,7 +172,7 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
   /// ```
   @override
   Option<B> ap<B>(covariant Option<B Function(T t)> a) => a.match(
-        () => Option.none(),
+        () => const Option.none(),
         (f) => map(f),
       );
 
@@ -415,7 +415,7 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
   /// Build a [Option] from a [Either] by returning [Some] when `either` is [Right],
   /// [None] otherwise.
   static Option<R> fromEither<L, R>(Either<L, R> either) =>
-      either.match((_) => Option.none(), (r) => Some(r));
+      either.match((_) => const Option.none(), (r) => Some(r));
 
   /// {@template fpdart_safe_cast_option}
   /// Safely cast a value to type `T`.
@@ -459,10 +459,10 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
       predicate(value) ? Some(f(value)) : Option.none();
 
   /// Return a [None].
-  factory Option.none() => None<T>();
+  const factory Option.none() = None<T>;
 
   /// Return a `Some(a)`.
-  factory Option.of(T t) => Some(t);
+  const factory Option.of(T t) = Some<T>;
 
   /// Flat a [Option] contained inside another [Option] to be a single [Option].
   factory Option.flatten(Option<Option<T>> m) => m.flatMap(identity);
@@ -475,7 +475,7 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
     try {
       return Some(f());
     } catch (_) {
-      return Option.none();
+      return const Option.none();
     }
   }
 
@@ -485,7 +485,7 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
   /// while the right value of the [Either] will be the second of the tuple.
   static Tuple2<Option<A>, Option<B>> separate<A, B>(Option<Either<A, B>> m) =>
       m.match(
-        () => Tuple2(Option.none(), Option.none()),
+        () => Tuple2(const Option.none(), const Option.none()),
         (either) => Tuple2(either.getLeft(), either.getRight()),
       );
 
@@ -503,12 +503,12 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
   /// Build an instance of [Monoid] in which the `empty` value is [None] and the
   /// `combine` function is based on the **first** [Option] if it is [Some], otherwise the second.
   static Monoid<Option<T>> getFirstMonoid<T>() =>
-      Monoid.instance(Option.none(), (a1, a2) => a1.isNone() ? a2 : a1);
+      Monoid.instance(const Option.none(), (a1, a2) => a1.isNone() ? a2 : a1);
 
   /// Build an instance of [Monoid] in which the `empty` value is [None] and the
   /// `combine` function is based on the **second** [Option] if it is [Some], otherwise the first.
   static Monoid<Option<T>> getLastMonoid<T>() =>
-      Monoid.instance(Option.none(), (a1, a2) => a2.isNone() ? a1 : a2);
+      Monoid.instance(const Option.none(), (a1, a2) => a2.isNone() ? a1 : a2);
 
   /// Build an instance of [Monoid] in which the `empty` value is [None] and the
   /// `combine` function uses the given `semigroup` to combine the values of both [Option]
@@ -517,7 +517,7 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
   /// If one of the [Option] is [None], then calling `combine` returns [None].
   static Monoid<Option<T>> getMonoid<T>(Semigroup<T> semigroup) =>
       Monoid.instance(
-          Option.none(),
+          const Option.none(),
           (a1, a2) => a1.flatMap((v1) => a2.flatMap(
                 (v2) => Some(semigroup.combine(v1, v2)),
               )));
@@ -597,7 +597,7 @@ class Some<T> extends Option<T> {
 
   @override
   Option<Z> filterMap<Z>(Option<Z> Function(T t) f) => f(_value).match(
-        () => Option.none(),
+        () => const Option.none(),
         Some.new,
       );
 
@@ -645,13 +645,14 @@ class None<T> extends Option<T> {
       flatMap((a) => mc.flatMap((c) => md.map((d) => f(a, c, d))));
 
   @override
-  Option<B> map<B>(B Function(T t) f) => Option.none();
+  Option<B> map<B>(B Function(T t) f) => const Option.none();
 
   @override
   B foldRight<B>(B b, B Function(B acc, T t) f) => b;
 
   @override
-  Option<B> flatMap<B>(covariant Option<B> Function(T t) f) => Option.none();
+  Option<B> flatMap<B>(covariant Option<B> Function(T t) f) =>
+      const Option.none();
 
   @override
   T getOrElse(T Function() orElse) => orElse();
@@ -663,7 +664,7 @@ class None<T> extends Option<T> {
   B match<B>(B Function() onNone, B Function(T t) onSome) => onNone();
 
   @override
-  Option<Z> extend<Z>(Z Function(Option<T> t) f) => Option.none();
+  Option<Z> extend<Z>(Z Function(Option<T> t) f) => const Option.none();
 
   @override
   bool isSome() => false;
@@ -672,10 +673,10 @@ class None<T> extends Option<T> {
   bool isNone() => true;
 
   @override
-  Option<T> filter(bool Function(T t) f) => Option.none();
+  Option<T> filter(bool Function(T t) f) => const Option.none();
 
   @override
-  Option<Z> filterMap<Z>(Option<Z> Function(T t) f) => Option.none();
+  Option<Z> filterMap<Z>(Option<Z> Function(T t) f) => const Option.none();
 
   @override
   T? toNullable() => null;

--- a/lib/src/task_option.dart
+++ b/lib/src/task_option.dart
@@ -144,7 +144,7 @@ class TaskOption<R> extends HKT<_TaskOptionHKT, R>
   factory TaskOption.some(R r) => TaskOption(() async => Option.of(r));
 
   /// Build a [TaskOption] that returns a [None].
-  factory TaskOption.none() => TaskOption(() async => Option.none());
+  factory TaskOption.none() => TaskOption(() async => const Option.none());
 
   /// Build a [TaskOption] from the result of running `task`.
   factory TaskOption.fromTask(Task<R> task) =>
@@ -159,7 +159,8 @@ class TaskOption<R> extends HKT<_TaskOptionHKT, R>
   /// Otherwise return [None].
   factory TaskOption.fromPredicate(R value, bool Function(R a) predicate) =>
       TaskOption(
-          () async => predicate(value) ? Option.of(value) : Option.none());
+        () async => predicate(value) ? Option.of(value) : const Option.none(),
+      );
 
   /// Converts a [Future] that may throw to a [Future] that never throws
   /// but returns a [Option] instead.
@@ -170,7 +171,7 @@ class TaskOption<R> extends HKT<_TaskOptionHKT, R>
         try {
           return Option.of(await run());
         } catch (_) {
-          return Option.none();
+          return const Option.none();
         }
       });
 
@@ -267,7 +268,7 @@ class TaskOption<R> extends HKT<_TaskOptionHKT, R>
   /// Build a [TaskOption] from `either` that returns [None] when
   /// `either` is [Left], otherwise it returns [Some].
   static TaskOption<R> fromEither<L, R>(Either<L, R> either) =>
-      TaskOption(() async => either.match((_) => Option.none(), some));
+      TaskOption(() async => either.match((_) => const Option.none(), some));
 
   /// Converts a [Future] that may throw to a [Future] that never throws
   /// but returns a [Option] instead.


### PR DESCRIPTION
While the `None()` and `Some()` constructors are already constant, some users prefer using the `Option.of` and `Option.none` factories. In this PR, I made them constant and replaced it in the Option source where possible (it can't be const in some places because of generic types).

Side effects:
People who have the [prefer_const_constructors](https://dart.dev/tools/linter-rules#prefer_const_constructors) lint enabled will get a bunch of info issues in the linter if they used the factories, but it's also a good thing, and that rule has a quick fix.