### PR TITLE
refactor: improve fromJson support

### DIFF
--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -545,7 +545,7 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
     dynamic json,
     T Function(dynamic json) fromJsonT,
   ) =>
-      json != null ? Option.of(fromJsonT(json)) : Option.none();
+      json != null ? Option.tryCatch(() => fromJsonT(json)) : Option.none();
 
   /// Converts to Json.
   ///

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -541,7 +541,11 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
   /// Converts from Json.
   ///
   /// Json serialization support for `json_serializable` with `@JsonSerializable`.
-  factory Option.fromJson(dynamic json) => Option<T>.fromNullable(json as T?);
+  factory Option.fromJson(
+    dynamic json,
+    T Function(dynamic json) fromJsonT,
+  ) =>
+      json != null ? Option.of(fromJsonT(json)) : Option.none();
 
   /// Converts to Json.
   ///

--- a/test/src/option_test.dart
+++ b/test/src/option_test.dart
@@ -340,6 +340,31 @@ void main() {
       });
     });
 
+    group('fromJson', () {
+      test('int', () {
+        final option = Option<int>.fromJson(10, (a) => a as int);
+        option.matchTestSome((some) => expect(some, 10));
+      });
+
+      test('DateTime', () {
+        final now = DateTime.now();
+        final option = Option<DateTime>.fromJson(
+            now.toIso8601String(), (a) => DateTime.parse(a as String));
+        option.matchTestSome((some) => expect(some, now));
+      });
+
+      test('DateTime failure', () {
+        final option = Option<DateTime>.fromJson(
+            "fail", (a) => DateTime.parse(a as String));
+        expect(option, isA<None>());
+      });
+
+      test('null', () {
+        final option = Option<int>.fromJson(null, (a) => a as int);
+        expect(option, isA<None>());
+      });
+    });
+
     group('fromPredicate', () {
       test('Some', () {
         final option = Option<int>.fromPredicate(10, (a) => a > 5);


### PR DESCRIPTION
Allow for decoding of non-primitive types (with custom fromJson constructors)