### PR TITLE
Do notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.6.0-dev.1 - 8 March 2023
+- Do notation [#97](https://github.com/SandroMaglione/fpdart/pull/97) 🎉
+
 # v0.5.0 - 4 March 2023
 - Updates to `Option` type [#92](https://github.com/SandroMaglione/fpdart/pull/92)  [⚠️ **BREAKING CHANGE**]
   - Added `const factory` constructor for `None` (fixes [#95](https://github.com/SandroMaglione/fpdart/issues/95))

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Check out also this series of articles about functional programming with `fpdart
 ```yaml
 # pubspec.yaml
 dependencies:
-  fpdart: ^0.5.0 # Check out the latest version
+  fpdart: ^0.6.0-dev.1 # Check out the latest version
 ```
 
 ## ✨ Examples

--- a/example/do_notation/main.dart
+++ b/example/do_notation/main.dart
@@ -1,0 +1,83 @@
+import 'package:fpdart/fpdart.dart';
+
+TaskEither<String, String> getUsernameFromId(int id) => TaskEither.of('sandro');
+TaskEither<String, String> getProfilePicture(String username) =>
+    TaskEither.of('image');
+int getPictureWidth(String image) => 10;
+TaskEither<String, bool> updatePictureWidth(int width) => TaskEither.of(true);
+
+Future<String> getUsernameFromIdLinear(int id) async => 'sandro';
+Future<String> getProfilePictureLinear(String username) async => 'image';
+int getPictureWidthLinear(String image) => 10;
+Future<bool> updatePictureWidthLinear(int width) async => true;
+
+/// Linear (no fpdart)
+Future<bool> changePictureSizeFromIdLinear(int id) async {
+  final username = await getUsernameFromIdLinear(id);
+  final image = await getProfilePictureLinear(username);
+  final width = getPictureWidthLinear(image);
+  return updatePictureWidthLinear(width);
+}
+
+/// Chaining
+TaskEither<String, bool> changePictureSizeFromId(int id) =>
+    getUsernameFromId(id)
+        .flatMap((username) => getProfilePicture(username))
+        .map((image) => getPictureWidth(image))
+        .flatMap((width) => updatePictureWidth(width));
+
+/// Do notation
+TaskEither<String, bool> changePictureSizeFromIdDo(int id) =>
+    TaskEither<String, bool>.Do(
+      ($) async {
+        final username = await $(getUsernameFromId(id));
+        final image = await $(getProfilePicture(username));
+        final width = getPictureWidth(image);
+        return $(updatePictureWidth(width));
+      },
+    );
+
+/// [map]: Update value inside [Option]
+Option<int> map() => Option.of(10)
+    .map(
+      (a) => a + 1,
+    )
+    .map(
+      (b) => b * 3,
+    )
+    .map(
+      (c) => c - 4,
+    );
+
+Option<int> mapDo() => Option.Do(($) {
+      final a = $(Option.of(10));
+      final b = a + 1;
+      final c = b * 3;
+      return c - 4;
+    });
+
+/// [flatMap]: Chain [Option]
+Option<int> flatMap() => Option.of(10)
+    .flatMap(
+      (a) => Option.of(a + 1),
+    )
+    .flatMap(
+      (b) => Option.of(b * 3),
+    )
+    .flatMap(
+      (c) => Option.of(c - 4),
+    );
+
+Option<int> flatMapDo() => Option.Do(($) {
+      final a = $(Option.of(10));
+      final b = $(Option.of(a + 1));
+      final c = $(Option.of(b * 3));
+      return $(Option.of(c - 4));
+    });
+
+/// [andThen]: Chain [Option] without storing its value
+Option<int> andThen() => Option.of(10).andThen(() => Option.of(20));
+Option<int> andThenDo() => Option.Do(($) {
+      $(Option.of(10)); // Chain Option, but do not store the result
+      return 20;
+    });

--- a/example/json_serializable/pubspec.lock
+++ b/example/json_serializable/pubspec.lock
@@ -183,7 +183,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.6.0-dev.1"
   frontend_server_client:
     dependency: transitive
     description:

--- a/example/managing_imports/pubspec.lock
+++ b/example/managing_imports/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.6.0-dev.1"
   frontend_server_client:
     dependency: transitive
     description:

--- a/example/open_meteo_api/pubspec.lock
+++ b/example/open_meteo_api/pubspec.lock
@@ -183,7 +183,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.6.0-dev.1"
   frontend_server_client:
     dependency: transitive
     description:

--- a/example/pokeapi_functional/README.md
+++ b/example/pokeapi_functional/README.md
@@ -5,5 +5,5 @@ A new Flutter project.
 ## Getting Started
 
 - `flutter pub get`
-- `flutter pub run build_runner build`
+- `dart run build_runner build`
 - `flutter run -d chrome`

--- a/example/pokeapi_functional/lib/api/fetch_pokemon.dart
+++ b/example/pokeapi_functional/lib/api/fetch_pokemon.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:http/http.dart' as http;
 import 'package:fpdart/fpdart.dart';
+import 'package:http/http.dart' as http;
 import 'package:pokeapi_functional/constants/constants.dart';
 import 'package:pokeapi_functional/models/pokemon.dart';
 
@@ -51,9 +51,17 @@ TaskEither<String, Pokemon> fetchPokemon(int pokemonId) => TaskEither.tryCatch(
 ///
 /// All the functions are simply chained together following the principle of composability.
 TaskEither<String, Pokemon> fetchPokemonFromUserInput(String pokemonId) =>
-    _validateUserPokemonId(pokemonId).flatMapTask(fetchPokemon);
+    TaskEither.Do(($) async {
+      final validPokemonId = await $(_validateUserPokemonId(
+        pokemonId,
+      ).toTaskEither());
+      return $(fetchPokemon(validPokemonId));
+    });
 
-TaskEither<String, Pokemon> fetchRandomPokemon() => randomInt(
-      Constants.minimumPokemonId,
-      Constants.maximumPokemonId + 1,
-    ).toIOEither<String>().flatMapTask(fetchPokemon);
+TaskEither<String, Pokemon> fetchRandomPokemon = TaskEither.Do(($) async {
+  final pokemonId = await $(randomInt(
+    Constants.minimumPokemonId,
+    Constants.maximumPokemonId + 1,
+  ).toTaskEither());
+  return $(fetchPokemon(pokemonId));
+});

--- a/example/pokeapi_functional/lib/controllers/pokemon_provider.dart
+++ b/example/pokeapi_functional/lib/controllers/pokemon_provider.dart
@@ -10,7 +10,7 @@ part 'pokemon_provider.g.dart';
 class PokemonState extends _$PokemonState {
   @override
   FutureOr<Pokemon> build() async =>
-      fetchRandomPokemon().getOrElse((l) => throw Exception(l)).run();
+      fetchRandomPokemon.getOrElse((l) => throw Exception(l)).run();
 
   /// User request, try to convert user input to [int] and then
   /// request the pokemon if successful.

--- a/example/pokeapi_functional/pubspec.lock
+++ b/example/pokeapi_functional/pubspec.lock
@@ -265,7 +265,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.6.0-dev.1"
   freezed:
     dependency: "direct main"
     description:

--- a/example/pokeapi_functional/pubspec.lock
+++ b/example/pokeapi_functional/pubspec.lock
@@ -390,10 +390,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "586678f20e112219ed0f73215f01bcdf1d769824ba2ebae45ad918a9bfde9bdb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
   meta:
     dependency: transitive
     description:
@@ -531,10 +531,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -587,10 +587,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: daadc9baabec998b062c9091525aa95786508b1c48e9c30f1f891b8bf6ff2e64
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.2"
   timing:
     dependency: transitive
     description:

--- a/example/read_write_file/pubspec.lock
+++ b/example/read_write_file/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.6.0-dev.1"
   lint:
     dependency: "direct dev"
     description:

--- a/example/src/either/shopping/functional.dart
+++ b/example/src/either/shopping/functional.dart
@@ -5,23 +5,25 @@ class Market {
 
   // I want to buy a Banana, an Apple, and a Pear. If either one
   // of these is missing, I will not but anything 😒
-  Option<String> buyBanana() => getRandomOption('🍌');
-  Option<String> buyApple() => getRandomOption('🍎');
-  Option<String> buyPear() => getRandomOption('🍐');
+  Either<String, String> buyBanana() => getRandomEither('🍌', "We got no 🍌");
+  Either<String, String> buyApple() => getRandomEither('🍎', "We got no 🍎");
+  Either<String, String> buyPear() => getRandomEither('🍐', "We got no 🍐");
 
-  Option<int> buyAmount() => getRandomOption(randomInt(1, 10).run());
+  Either<String, int> buyAmount() =>
+      getRandomEither(randomInt(1, 10).run(), "Empty 💁🏼‍♂️");
 }
 
-Option<T> getRandomOption<T>(T value) => randomBool()
-    .map(
-      (isValid) => isValid ? some(value) : none<T>(),
+Either<L, R> getRandomEither<L, R>(R right, L left) => randomBool()
+    .map<Either<L, R>>(
+      (isValid) => isValid ? Either.of(right) : Either.left(left),
     )
     .run();
 
 // I go shopping in the Shopping Center. If it is closed, then
 // I will go to the Local Market (which is always open 🥇).
-Option<Market> goToShoppingCenter() => getRandomOption(const Market());
-Option<Market> goToLocalMarket() => some(const Market());
+Either<String, Market> goToShoppingCenter() =>
+    getRandomEither(const Market(), "Shopping center closed ☝️");
+Either<String, Market> goToLocalMarket() => Either.of(const Market());
 
 // Combine all the instructions and go shopping! 🛒
 String goShopping() => goToShoppingCenter()
@@ -30,17 +32,15 @@ String goShopping() => goToShoppingCenter()
       (market) => market.buyBanana().flatMap(
             (banana) => market.buyApple().flatMap(
                   (apple) => market.buyPear().flatMap(
-                        (pear) => Option.of('Shopping: $banana, $apple, $pear'),
+                        (pear) => Either.of('Shopping: $banana, $apple, $pear'),
                       ),
                 ),
           ),
     )
-    .getOrElse(
-      () => 'I did not find 🍌 or 🍎 or 🍐, so I did not buy anything 🤷‍♂️',
-    );
+    .getOrElse(identity);
 
 // Combine all the instructions and go shopping! 🛒
-String goShoppingDo() => Option.Do(
+String goShoppingDo() => Either<String, String>.Do(
       ($) {
         final market = $(goToShoppingCenter().alt(goToLocalMarket));
         final amount = $(market.buyAmount());
@@ -51,24 +51,22 @@ String goShoppingDo() => Option.Do(
 
         return 'Shopping: $banana, $apple, $pear';
       },
-    ).getOrElse(
-      () => 'I did not find 🍌 or 🍎 or 🍐, so I did not buy anything 🤷‍♂️',
-    );
+    ).getOrElse(identity);
 
 // Combine all the instructions and go shopping! 🛒
 String goShoppingDoFlatMap() => goToShoppingCenter()
     .alt(goToLocalMarket)
     .flatMap(
-      (market) => Option.Do(($) {
+      /// Not required types here, since [Left] inferred from chain,
+      /// and [Right] from the return type of `Do`
+      (market) => Either.Do(($) {
         final banana = $(market.buyBanana());
         final apple = $(market.buyApple());
         final pear = $(market.buyPear());
         return 'Shopping: $banana, $apple, $pear';
       }),
     )
-    .getOrElse(
-      () => 'I did not find 🍌 or 🍎 or 🍐, so I did not buy anything 🤷‍♂️',
-    );
+    .getOrElse(identity);
 
 void main() {
   for (int i = 0; i < 100; i++) {

--- a/example/src/option/shopping/functional.dart
+++ b/example/src/option/shopping/functional.dart
@@ -8,6 +8,8 @@ class Market {
   Option<String> buyBanana() => getRandomOption('🍌');
   Option<String> buyApple() => getRandomOption('🍎');
   Option<String> buyPear() => getRandomOption('🍐');
+
+  Option<int> buyAmount() => getRandomOption(randomInt(1, 10).run());
 }
 
 Option<T> getRandomOption<T>(T value) => randomBool()
@@ -38,12 +40,15 @@ String goShopping() => goToShoppingCenter()
     );
 
 // Combine all the instructions and go shopping! 🛒
-String goShoppingDo() => Option.DoInit<String>(
+String goShoppingDo() => Option.Do(
       ($) {
         final market = $(goToShoppingCenter().alt(goToLocalMarket));
+        final amount = $(market.buyAmount());
+
         final banana = $(market.buyBanana());
         final apple = $(market.buyApple());
         final pear = $(market.buyPear());
+
         return 'Shopping: $banana, $apple, $pear';
       },
     ).getOrElse(
@@ -51,17 +56,21 @@ String goShoppingDo() => Option.DoInit<String>(
     );
 
 // Combine all the instructions and go shopping! 🛒
-String goShoppingDoContinue() =>
-    goToShoppingCenter().alt(goToLocalMarket).Do<String>(
-      (market, $) {
+String goShoppingDoFlatMap() => goToShoppingCenter()
+    .alt(goToLocalMarket)
+    .flatMap(
+      (market) => Option.Do(($) {
         final banana = $(market.buyBanana());
         final apple = $(market.buyApple());
         final pear = $(market.buyPear());
         return 'Shopping: $banana, $apple, $pear';
-      },
-    ).getOrElse(
+      }),
+    )
+    .getOrElse(
       () => 'I did not find 🍌 or 🍎 or 🍐, so I did not buy anything 🤷‍♂️',
     );
+
+final doThen = Option.of(10)(Option.Do(($) => $(Option.of("Some"))));
 
 void main() {
   for (int i = 0; i < 100; i++) {

--- a/example/src/option/shopping/functional.dart
+++ b/example/src/option/shopping/functional.dart
@@ -50,6 +50,19 @@ String goShoppingDo() => Option.DoInit<String>(
       () => 'I did not find 🍌 or 🍎 or 🍐, so I did not buy anything 🤷‍♂️',
     );
 
+// Combine all the instructions and go shopping! 🛒
+String goShoppingDoContinue() =>
+    goToShoppingCenter().alt(goToLocalMarket).Do<String>(
+      (market, $) {
+        final banana = $(market.buyBanana());
+        final apple = $(market.buyApple());
+        final pear = $(market.buyPear());
+        return 'Shopping: $banana, $apple, $pear';
+      },
+    ).getOrElse(
+      () => 'I did not find 🍌 or 🍎 or 🍐, so I did not buy anything 🤷‍♂️',
+    );
+
 void main() {
   for (int i = 0; i < 100; i++) {
     final shopping = goShopping();

--- a/example/src/option/shopping/functional.dart
+++ b/example/src/option/shopping/functional.dart
@@ -1,5 +1,15 @@
 import 'package:fpdart/fpdart.dart';
 
+class Market {
+  const Market();
+
+  // I want to buy a Banana, an Apple, and a Pear. If either one
+  // of these is missing, I will not but anything 😒
+  Option<String> buyBanana() => getRandomOption('🍌');
+  Option<String> buyApple() => getRandomOption('🍎');
+  Option<String> buyPear() => getRandomOption('🍐');
+}
+
 Option<T> getRandomOption<T>(T value) => randomBool()
     .map(
       (isValid) => isValid ? some(value) : none<T>(),
@@ -8,30 +18,35 @@ Option<T> getRandomOption<T>(T value) => randomBool()
 
 // I go shopping in the Shopping Center. If it is closed, then
 // I will go to the Local Market (which is always open 🥇).
-Option<Unit> goToShoppingCenter() => getRandomOption(unit);
-Option<Unit> goToLocalMarket() => some(unit);
-
-// I want to buy a Banana, an Apple, and a Pear. If either one
-// of these is missing, I will not but anything 😒
-Option<String> buyBanana() => getRandomOption('🍌');
-Option<String> buyApple() => getRandomOption('🍎');
-Option<String> buyPear() => getRandomOption('🍐');
+Option<Market> goToShoppingCenter() => getRandomOption(const Market());
+Option<Market> goToLocalMarket() => some(const Market());
 
 // Combine all the instructions and go shopping! 🛒
 String goShopping() => goToShoppingCenter()
-    .alt(
-      goToLocalMarket,
-    )
-    .andThen(
-      () => buyBanana().flatMap(
-        (banana) => buyApple().flatMap(
-          (apple) => buyPear().flatMap(
-            (pear) => Option.of('Shopping: $banana, $apple, $pear'),
+    .alt(goToLocalMarket)
+    .flatMap(
+      (market) => market.buyBanana().flatMap(
+            (banana) => market.buyApple().flatMap(
+                  (apple) => market.buyPear().flatMap(
+                        (pear) => Option.of('Shopping: $banana, $apple, $pear'),
+                      ),
+                ),
           ),
-        ),
-      ),
     )
     .getOrElse(
+      () => 'I did not find 🍌 or 🍎 or 🍐, so I did not buy anything 🤷‍♂️',
+    );
+
+// Combine all the instructions and go shopping! 🛒
+String goShoppingDo() => Option.DoInit<String>(
+      ($) {
+        final market = $(goToShoppingCenter().alt(goToLocalMarket));
+        final banana = $(market.buyBanana());
+        final apple = $(market.buyApple());
+        final pear = $(market.buyPear());
+        return 'Shopping: $banana, $apple, $pear';
+      },
+    ).getOrElse(
       () => 'I did not find 🍌 or 🍎 or 🍐, so I did not buy anything 🤷‍♂️',
     );
 
@@ -39,5 +54,10 @@ void main() {
   for (int i = 0; i < 100; i++) {
     final shopping = goShopping();
     print(shopping);
+  }
+
+  for (int i = 0; i < 100; i++) {
+    final shopping = goShoppingDo();
+    print('[Do]: $shopping');
   }
 }

--- a/lib/src/either.dart
+++ b/lib/src/either.dart
@@ -15,6 +15,19 @@ Either<L, R> right<L, R>(R r) => Right<L, R>(r);
 /// Shortcut for `Either.left(l)`.
 Either<L, R> left<L, R>(L l) => Left<L, R>(l);
 
+class _EitherThrow<L> {
+  final L value;
+  const _EitherThrow(this.value);
+}
+
+typedef DoAdapterEither<L> = R Function<R>(Either<L, R>);
+DoAdapterEither<L> _doAdapter<L>() =>
+    <R>(Either<L, R> either) => either.getOrElse(
+          (l) => throw _EitherThrow(l),
+        );
+
+typedef DoFunctionEither<L, R> = R Function(DoAdapterEither<L> $);
+
 /// Tag the [HKT2] interface for the actual [Either].
 abstract class _EitherHKT {}
 
@@ -33,6 +46,13 @@ abstract class Either<L, R> extends HKT2<_EitherHKT, L, R>
         Alt2<_EitherHKT, L, R>,
         Extend2<_EitherHKT, L, R> {
   const Either();
+
+  /// Initialize a **Do Notation** chain.
+  // ignore: non_constant_identifier_names
+  factory Either.Do(DoFunctionEither<L, R> f) => Either.tryCatch(
+        () => f(_doAdapter<L>()),
+        (error, _) => (error as _EitherThrow<L>).value,
+      );
 
   /// Return the result of `f` called with `b` and the value of [Right].
   /// If this [Either] is [Left], return `b`.

--- a/lib/src/either.dart
+++ b/lib/src/either.dart
@@ -49,10 +49,13 @@ abstract class Either<L, R> extends HKT2<_EitherHKT, L, R>
 
   /// Initialize a **Do Notation** chain.
   // ignore: non_constant_identifier_names
-  factory Either.Do(DoFunctionEither<L, R> f) => Either.tryCatch(
-        () => f(_doAdapter<L>()),
-        (error, _) => (error as _EitherThrow<L>).value,
-      );
+  factory Either.Do(DoFunctionEither<L, R> f) {
+    try {
+      return Either.of(f(_doAdapter<L>()));
+    } on _EitherThrow<L> catch (e) {
+      return Either.left(e.value);
+    }
+  }
 
   /// Return the result of `f` called with `b` and the value of [Right].
   /// If this [Either] is [Left], return `b`.

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -1,5 +1,10 @@
 import 'package:fpdart/fpdart.dart';
 
+typedef DoAdapterIO = A Function<A>(IO<A>);
+A _doAdapter<A>(IO<A> io) => io.run();
+
+typedef DoFunctionIO<A> = A Function(DoAdapterIO $);
+
 /// Tag the [HKT] interface for the actual [Option].
 abstract class _IOHKT {}
 
@@ -13,6 +18,10 @@ class IO<A> extends HKT<_IOHKT, A>
 
   /// Build an instance of [IO] from `A Function()`.
   const IO(this._run);
+
+  /// Initialize a **Do Notation** chain.
+  // ignore: non_constant_identifier_names
+  factory IO.Do(DoFunctionIO<A> f) => IO(() => f(_doAdapter));
 
   /// Flat a [IO] contained inside another [IO] to be a single [IO].
   factory IO.flatten(IO<IO<A>> io) => io.flatMap(identity);

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -37,7 +37,7 @@ Option<T> option<T>(T value, bool Function(T) predicate) =>
     Option.fromPredicate(value, predicate);
 
 typedef DoAdapterOption = A Function<A>(Option<A>);
-A _doAdapter<A>(Option<A> option) => option.getOrElse(() => throw None<A>());
+A _doAdapter<A>(Option<A> option) => option.getOrElse(() => throw const None());
 
 typedef DoFunctionOption<A> = A Function(DoAdapterOption $);
 
@@ -80,70 +80,6 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
   // ignore: non_constant_identifier_names
   factory Option.Do(DoFunctionOption<T> f) =>
       Option.tryCatch(() => f(_doAdapter));
-
-  /// Return the result of `f` called with `b` and the value of [Some].
-  /// If this [Option] is [None], return `b`.
-  @override
-  B foldRight<B>(B b, B Function(B acc, T t) f);
-
-  /// Return the result of `f` called with `b` and the value of [Some].
-  /// If this [Option] is [None], return `b`.
-  @override
-  B foldLeft<B>(B b, B Function(B acc, T t) f) =>
-      foldMap<Endo<B>>(dualEndoMonoid(), (a) => (B b) => f(b, a))(b);
-
-  /// Use `monoid` to combine the value of [Some] applied to `f`.
-  @override
-  B foldMap<B>(Monoid<B> monoid, B Function(T t) f) =>
-      foldRight(monoid.empty, (b, a) => monoid.combine(f(a), b));
-
-  /// Return the result of `f` called with `b` and the value of [Some].
-  /// If this [Option] is [None], return `b`.
-  @override
-  B foldRightWithIndex<B>(B b, B Function(int i, B acc, T t) f) =>
-      foldRight<Tuple2<B, int>>(
-        Tuple2(b, length() - 1),
-        (t, a) => Tuple2(f(t.second, t.first, a), t.second - 1),
-      ).first;
-
-  /// Return the result of `f` called with `b` and the value of [Some].
-  /// If this [Option] is [None], return `b`.
-  @override
-  B foldLeftWithIndex<B>(B b, B Function(int i, B acc, T t) f) =>
-      foldLeft<Tuple2<B, int>>(
-        Tuple2(b, 0),
-        (t, a) => Tuple2(f(t.second, t.first, a), t.second + 1),
-      ).first;
-
-  /// Returns `1` when [Option] is [Some], `0` otherwise.
-  @override
-  int length() => foldLeft(0, (b, _) => b + 1);
-
-  /// Return the result of `predicate` applied to the value of [Some].
-  /// If the [Option] is [None], returns `false`.
-  @override
-  bool any(bool Function(T t) predicate) => foldMap(boolOrMonoid(), predicate);
-
-  /// Return the result of `predicate` applied to the value of [Some].
-  /// If the [Option] is [None], returns `true`.
-  @override
-  bool all(bool Function(T t) predicate) => foldMap(boolAndMonoid(), predicate);
-
-  /// Use `monoid` to combine the value of [Some].
-  @override
-  T concatenate(Monoid<T> monoid) => foldMap(monoid, identity);
-
-  /// Return the value of this [Option] if it is [Some], otherwise return `a`.
-  @override
-  Option<T> plus(covariant Option<T> a);
-
-  /// Return `Some(a)`.
-  @override
-  Option<T> prepend(T t) => Some(t);
-
-  /// If this [Option] is [None], return `Some(a)`. Otherwise return this [Some].
-  @override
-  Option<T> append(T t);
 
   /// Change the value of type `T` to a value of type `B` using function `f`.
   /// ```dart

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -13,7 +13,6 @@ import 'typeclass/monad.dart';
 import 'typeclass/monoid.dart';
 import 'typeclass/order.dart';
 import 'typeclass/semigroup.dart';
-import 'unit.dart';
 
 /// Return a `Some(t)`.
 ///
@@ -77,20 +76,10 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
         Filterable<_OptionHKT, T> {
   const Option();
 
-  /// Initialize a **Do Notation** chain without previous values.
+  /// Initialize a **Do Notation** chain.
   // ignore: non_constant_identifier_names
-  static Option<A> DoInit<A>(DoThenFunctionOption<A> f) =>
-      Option.of(unit).DoThen(f);
-
-  /// Initialize a **Do Notation** chain, ignoring the current value inside [Option].
-  // ignore: non_constant_identifier_names
-  Option<A> DoThen<A>(DoThenFunctionOption<A> f) =>
+  factory Option.Do(DoThenFunctionOption<T> f) =>
       Option.tryCatch(() => f(_doAdapter));
-
-  /// Initialize a **Do Notation** from the current value inside [Option].
-  // ignore: non_constant_identifier_names
-  Option<A> Do<A>(DoFunctionOption<T, A> f) =>
-      flatMap((t) => Option.tryCatch(() => f(t, _doAdapter)));
 
   /// Return the result of `f` called with `b` and the value of [Some].
   /// If this [Option] is [None], return `b`.

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -37,9 +37,9 @@ Option<T> option<T>(T value, bool Function(T) predicate) =>
     Option.fromPredicate(value, predicate);
 
 typedef DoAdapterOption = A Function<A>(Option<A>);
-typedef DoThenFunctionOption<A> = A Function(DoAdapterOption $);
-typedef DoFunctionOption<T, A> = A Function(T t, DoAdapterOption $);
 A _doAdapter<A>(Option<A> option) => option.getOrElse(() => throw None<A>());
+
+typedef DoFunctionOption<A> = A Function(DoAdapterOption $);
 
 /// Tag the [HKT] interface for the actual [Option].
 abstract class _OptionHKT {}
@@ -78,7 +78,7 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
 
   /// Initialize a **Do Notation** chain.
   // ignore: non_constant_identifier_names
-  factory Option.Do(DoThenFunctionOption<T> f) =>
+  factory Option.Do(DoFunctionOption<T> f) =>
       Option.tryCatch(() => f(_doAdapter));
 
   /// Return the result of `f` called with `b` and the value of [Some].

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -36,8 +36,13 @@ Option<T> optionOf<T>(T? t) => Option.fromNullable(t);
 Option<T> option<T>(T value, bool Function(T) predicate) =>
     Option.fromPredicate(value, predicate);
 
+class _OptionThrow {
+  const _OptionThrow();
+}
+
 typedef DoAdapterOption = A Function<A>(Option<A>);
-A _doAdapter<A>(Option<A> option) => option.getOrElse(() => throw const None());
+A _doAdapter<A>(Option<A> option) =>
+    option.getOrElse(() => throw const _OptionThrow());
 
 typedef DoFunctionOption<A> = A Function(DoAdapterOption $);
 
@@ -78,8 +83,13 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
 
   /// Initialize a **Do Notation** chain.
   // ignore: non_constant_identifier_names
-  factory Option.Do(DoFunctionOption<T> f) =>
-      Option.tryCatch(() => f(_doAdapter));
+  factory Option.Do(DoFunctionOption<T> f) {
+    try {
+      return Option.of(f(_doAdapter));
+    } on _OptionThrow catch (_) {
+      return const Option.none();
+    }
+  }
 
   /// Change the value of type `T` to a value of type `B` using function `f`.
   /// ```dart

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -13,6 +13,7 @@ import 'typeclass/monad.dart';
 import 'typeclass/monoid.dart';
 import 'typeclass/order.dart';
 import 'typeclass/semigroup.dart';
+import 'unit.dart';
 
 /// Return a `Some(t)`.
 ///
@@ -35,6 +36,10 @@ Option<T> optionOf<T>(T? t) => Option.fromNullable(t);
 /// Same as initializing `Option.fromPredicate(value, predicate)`.
 Option<T> option<T>(T value, bool Function(T) predicate) =>
     Option.fromPredicate(value, predicate);
+
+typedef DoAdapterOption = A Function<A>(Option<A>);
+typedef DoFunctionOption<A> = A Function(DoAdapterOption $);
+A _doAdapter<A>(Option<A> option) => option.getOrElse(() => throw None<A>());
 
 /// Tag the [HKT] interface for the actual [Option].
 abstract class _OptionHKT {}
@@ -70,6 +75,77 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
         Extend<_OptionHKT, T>,
         Filterable<_OptionHKT, T> {
   const Option();
+
+  // ignore: non_constant_identifier_names
+  static Option<A> DoInit<A>(DoFunctionOption<A> f) => Option.of(unit).Do(f);
+
+  // ignore: non_constant_identifier_names
+  Option<A> Do<A>(DoFunctionOption<A> f) =>
+      Option.tryCatch(() => f(_doAdapter));
+
+  /// Return the result of `f` called with `b` and the value of [Some].
+  /// If this [Option] is [None], return `b`.
+  @override
+  B foldRight<B>(B b, B Function(B acc, T t) f);
+
+  /// Return the result of `f` called with `b` and the value of [Some].
+  /// If this [Option] is [None], return `b`.
+  @override
+  B foldLeft<B>(B b, B Function(B acc, T t) f) =>
+      foldMap<Endo<B>>(dualEndoMonoid(), (a) => (B b) => f(b, a))(b);
+
+  /// Use `monoid` to combine the value of [Some] applied to `f`.
+  @override
+  B foldMap<B>(Monoid<B> monoid, B Function(T t) f) =>
+      foldRight(monoid.empty, (b, a) => monoid.combine(f(a), b));
+
+  /// Return the result of `f` called with `b` and the value of [Some].
+  /// If this [Option] is [None], return `b`.
+  @override
+  B foldRightWithIndex<B>(B b, B Function(int i, B acc, T t) f) =>
+      foldRight<Tuple2<B, int>>(
+        Tuple2(b, length() - 1),
+        (t, a) => Tuple2(f(t.second, t.first, a), t.second - 1),
+      ).first;
+
+  /// Return the result of `f` called with `b` and the value of [Some].
+  /// If this [Option] is [None], return `b`.
+  @override
+  B foldLeftWithIndex<B>(B b, B Function(int i, B acc, T t) f) =>
+      foldLeft<Tuple2<B, int>>(
+        Tuple2(b, 0),
+        (t, a) => Tuple2(f(t.second, t.first, a), t.second + 1),
+      ).first;
+
+  /// Returns `1` when [Option] is [Some], `0` otherwise.
+  @override
+  int length() => foldLeft(0, (b, _) => b + 1);
+
+  /// Return the result of `predicate` applied to the value of [Some].
+  /// If the [Option] is [None], returns `false`.
+  @override
+  bool any(bool Function(T t) predicate) => foldMap(boolOrMonoid(), predicate);
+
+  /// Return the result of `predicate` applied to the value of [Some].
+  /// If the [Option] is [None], returns `true`.
+  @override
+  bool all(bool Function(T t) predicate) => foldMap(boolAndMonoid(), predicate);
+
+  /// Use `monoid` to combine the value of [Some].
+  @override
+  T concatenate(Monoid<T> monoid) => foldMap(monoid, identity);
+
+  /// Return the value of this [Option] if it is [Some], otherwise return `a`.
+  @override
+  Option<T> plus(covariant Option<T> a);
+
+  /// Return `Some(a)`.
+  @override
+  Option<T> prepend(T t) => Some(t);
+
+  /// If this [Option] is [None], return `Some(a)`. Otherwise return this [Some].
+  @override
+  Option<T> append(T t);
 
   /// Change the value of type `T` to a value of type `B` using function `f`.
   /// ```dart

--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -9,6 +9,11 @@ import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
+typedef DoAdapterTask = Future<A> Function<A>(Task<A>);
+Future<A> _doAdapter<A>(Task<A> task) => task.run();
+
+typedef DoFunctionTask<A> = Future<A> Function(DoAdapterTask $);
+
 /// Tag the [HKT] interface for the actual [Task].
 abstract class _TaskHKT {}
 
@@ -21,6 +26,10 @@ class Task<A> extends HKT<_TaskHKT, A>
 
   /// Build a [Task] from a function returning a [Future].
   const Task(this._run);
+
+  /// Initialize a **Do Notation** chain.
+  // ignore: non_constant_identifier_names
+  factory Task.Do(DoFunctionTask<A> f) => Task(() => f(_doAdapter));
 
   /// Build a [Task] that returns `a`.
   factory Task.of(A a) => Task<A>(() async => a);

--- a/lib/src/task_either.dart
+++ b/lib/src/task_either.dart
@@ -42,10 +42,13 @@ class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
 
   /// Initialize a **Do Notation** chain.
   // ignore: non_constant_identifier_names
-  factory TaskEither.Do(DoFunctionTaskEither<L, R> f) => TaskEither.tryCatch(
-        () => f(_doAdapter<L>()),
-        (error, _) => (error as _TaskEitherThrow<L>).value,
-      );
+  factory TaskEither.Do(DoFunctionTaskEither<L, R> f) => TaskEither(() async {
+        try {
+          return Either.of(await f(_doAdapter<L>()));
+        } on _TaskEitherThrow<L> catch (e) {
+          return Either.left(e.value);
+        }
+      });
 
   /// Used to chain multiple functions that return a [TaskEither].
   ///

--- a/lib/src/task_either.dart
+++ b/lib/src/task_either.dart
@@ -8,6 +8,20 @@ import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
+class _TaskEitherThrow<L> {
+  final L value;
+  const _TaskEitherThrow(this.value);
+}
+
+typedef DoAdapterTaskEither<E> = Future<A> Function<A>(TaskEither<E, A>);
+DoAdapterTaskEither<L> _doAdapter<L>() =>
+    <A>(taskEither) => taskEither.run().then(
+          (either) => either.getOrElse((l) => throw _TaskEitherThrow(l)),
+        );
+
+typedef DoFunctionTaskEither<L, A> = Future<A> Function(
+    DoAdapterTaskEither<L> $);
+
 /// Tag the [HKT2] interface for the actual [TaskEither].
 abstract class _TaskEitherHKT {}
 
@@ -25,6 +39,13 @@ class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
 
   /// Build a [TaskEither] from a function returning a `Future<Either<L, R>>`.
   const TaskEither(this._run);
+
+  /// Initialize a **Do Notation** chain.
+  // ignore: non_constant_identifier_names
+  factory TaskEither.Do(DoFunctionTaskEither<L, R> f) => TaskEither.tryCatch(
+        () => f(_doAdapter<L>()),
+        (error, _) => (error as _TaskEitherThrow<L>).value,
+      );
 
   /// Used to chain multiple functions that return a [TaskEither].
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fpdart
-version: 0.5.0
+version: 0.6.0-dev.1
 homepage: https://www.sandromaglione.com/
 repository: https://github.com/SandroMaglione/fpdart
 description: Functional programming in Dart and Flutter. All the main functional programming types and patterns fully documented, tested, and with examples.

--- a/test/src/either_test.dart
+++ b/test/src/either_test.dart
@@ -1174,6 +1174,24 @@ void main() {
       });
     });
 
+    test('should rethrow if throw is used inside Do', () {
+      final doEither = () => Either<String, int>.Do(($) {
+            $(Either.of(10));
+            throw UnimplementedError();
+          });
+
+      expect(doEither, throwsA(const TypeMatcher<UnimplementedError>()));
+    });
+
+    test('should rethrow if Left is thrown inside Do', () {
+      final doEither = () => Either<String, int>.Do(($) {
+            $(Either.of(10));
+            throw Left('Error');
+          });
+
+      expect(doEither, throwsA(const TypeMatcher<Left>()));
+    });
+
     test('should no execute past the first Left', () {
       var mutable = 10;
       final doEitherLeft = Either<String, int>.Do(($) {

--- a/test/src/either_test.dart
+++ b/test/src/either_test.dart
@@ -1142,4 +1142,36 @@ void main() {
       });
     });
   });
+
+  group('Do Notation', () {
+    test('should return the correct value', () {
+      final doEither = Either.Do(($) => $(Either.of(10)));
+      doEither.matchTestRight((t) {
+        expect(t, 10);
+      });
+    });
+
+    test('should extract the correct values', () {
+      final doEither = Either.Do(($) {
+        final a = $(Either.of(10));
+        final b = $(Either.of(5));
+        return a + b;
+      });
+      doEither.matchTestRight((t) {
+        expect(t, 15);
+      });
+    });
+
+    test('should return Left if any Either is Left', () {
+      final doEither = Either<String, int>.Do(($) {
+        final a = $(Either.of(10));
+        final b = $(Either.of(5));
+        final c = $(Either<String, int>.left('Error'));
+        return a + b + c;
+      });
+      doEither.matchTestLeft((t) {
+        expect(t, 'Error');
+      });
+    });
+  });
 }

--- a/test/src/either_test.dart
+++ b/test/src/either_test.dart
@@ -1173,5 +1173,31 @@ void main() {
         expect(t, 'Error');
       });
     });
+
+    test('should no execute past the first Left', () {
+      var mutable = 10;
+      final doEitherLeft = Either<String, int>.Do(($) {
+        final a = $(Either.of(10));
+        final b = $(Either<String, int>.left("Error"));
+        mutable += 10;
+        return a + b;
+      });
+
+      expect(mutable, 10);
+      doEitherLeft.matchTestLeft((l) {
+        expect(l, "Error");
+      });
+
+      final doEitherRight = Either<String, int>.Do(($) {
+        final a = $(Either.of(10));
+        mutable += 10;
+        return a;
+      });
+
+      expect(mutable, 20);
+      doEitherRight.matchTestRight((t) {
+        expect(t, 10);
+      });
+    });
   });
 }

--- a/test/src/io_either_test.dart
+++ b/test/src/io_either_test.dart
@@ -692,34 +692,34 @@ void main() {
   });
 
   group('Do Notation', () {
-    test('should return the correct value', () async {
+    test('should return the correct value', () {
       final doIOEither = IOEither<String, int>.Do(($) => $(IOEither.of(10)));
-      final run = await doIOEither.run();
+      final run = doIOEither.run();
       run.matchTestRight((t) {
         expect(t, 10);
       });
     });
 
-    test('should extract the correct values', () async {
+    test('should extract the correct values', () {
       final doIOEither = IOEither<String, int>.Do(($) {
         final a = $(IOEither.of(10));
         final b = $(IOEither.of(5));
         return a + b;
       });
-      final run = await doIOEither.run();
+      final run = doIOEither.run();
       run.matchTestRight((t) {
         expect(t, 15);
       });
     });
 
-    test('should return Left if any Either is Left', () async {
+    test('should return Left if any Either is Left', () {
       final doIOEither = IOEither<String, int>.Do(($) {
         final a = $(IOEither.of(10));
         final b = $(IOEither.of(5));
         final c = $(IOEither<String, int>.left('Error'));
         return a + b + c;
       });
-      final run = await doIOEither.run();
+      final run = doIOEither.run();
       run.matchTestLeft((t) {
         expect(t, 'Error');
       });
@@ -743,7 +743,7 @@ void main() {
       expect(doIOEither.run, throwsA(const TypeMatcher<Left>()));
     });
 
-    test('should no execute past the first Left', () async {
+    test('should no execute past the first Left', () {
       var mutable = 10;
       final doIOEitherLeft = IOEither<String, int>.Do(($) {
         final a = $(IOEither.of(10));
@@ -752,7 +752,7 @@ void main() {
         return a + b;
       });
 
-      final runLeft = await doIOEitherLeft.run();
+      final runLeft = doIOEitherLeft.run();
       expect(mutable, 10);
       runLeft.matchTestLeft((l) {
         expect(l, "Error");
@@ -764,7 +764,7 @@ void main() {
         return a;
       });
 
-      final runRight = await doIOEitherRight.run();
+      final runRight = doIOEitherRight.run();
       expect(mutable, 20);
       runRight.matchTestRight((t) {
         expect(t, 10);

--- a/test/src/io_option_test.dart
+++ b/test/src/io_option_test.dart
@@ -497,5 +497,83 @@ void main() {
         expect(sideEffect, list.length);
       });
     });
+
+    group('Do Notation', () {
+      test('should return the correct value', () {
+        final doIOOption = IOOption<int>.Do(($) => $(IOOption.of(10)));
+        final run = doIOOption.run();
+        run.matchTestSome((t) {
+          expect(t, 10);
+        });
+      });
+
+      test('should extract the correct values', () {
+        final doIOOption = IOOption<int>.Do(($) {
+          final a = $(IOOption.of(10));
+          final b = $(IOOption.of(5));
+          return a + b;
+        });
+        final run = doIOOption.run();
+        run.matchTestSome((t) {
+          expect(t, 15);
+        });
+      });
+
+      test('should return Left if any Either is Left', () {
+        final doIOOption = IOOption<int>.Do(($) {
+          final a = $(IOOption.of(10));
+          final b = $(IOOption.of(5));
+          final c = $(IOOption<int>.none());
+          return a + b + c;
+        });
+        final run = doIOOption.run();
+        expect(run, isA<None>());
+      });
+
+      test('should rethrow if throw is used inside Do', () {
+        final doIOOption = IOOption<int>.Do(($) {
+          $(IOOption.of(10));
+          throw UnimplementedError();
+        });
+
+        expect(
+            doIOOption.run, throwsA(const TypeMatcher<UnimplementedError>()));
+      });
+
+      test('should rethrow if None is thrown inside Do', () {
+        final doIOOption = IOOption<int>.Do(($) {
+          $(IOOption.of(10));
+          throw const None();
+        });
+
+        expect(doIOOption.run, throwsA(const TypeMatcher<None>()));
+      });
+
+      test('should no execute past the first Left', () {
+        var mutable = 10;
+        final doIOOptionNone = IOOption<int>.Do(($) {
+          final a = $(IOOption.of(10));
+          final b = $(IOOption<int>.none());
+          mutable += 10;
+          return a + b;
+        });
+
+        final runNone = doIOOptionNone.run();
+        expect(mutable, 10);
+        expect(runNone, isA<None>());
+
+        final doIOOptionSome = IOOption<int>.Do(($) {
+          final a = $(IOOption.of(10));
+          mutable += 10;
+          return a;
+        });
+
+        final runSome = doIOOptionSome.run();
+        expect(mutable, 20);
+        runSome.matchTestSome((t) {
+          expect(t, 10);
+        });
+      });
+    });
   });
 }

--- a/test/src/io_test.dart
+++ b/test/src/io_test.dart
@@ -186,5 +186,37 @@ void main() {
       expect(result, ['10', '21', '32', '43', '54', '65']);
       expect(sideEffect, list.length);
     });
+
+    group('Do Notation', () {
+      test('should return the correct value', () {
+        final doIO = IO.Do(($) => $(IO.of(10)));
+        final run = doIO.run();
+        expect(run, 10);
+      });
+
+      test('should extract the correct values', () {
+        final doIO = IO.Do(($) {
+          final a = $(IO.of(10));
+          final b = $(IO.of(5));
+          return a + b;
+        });
+        final run = doIO.run();
+        expect(run, 15);
+      });
+
+      test('should not execute until run is called', () {
+        var mutable = 10;
+        final doIO = IO.Do(($) {
+          final a = $(IO.of(10));
+          final b = $(IO.of(5));
+          mutable += 10;
+          return a + b;
+        });
+        expect(mutable, 10);
+        final run = doIO.run();
+        expect(mutable, 20);
+        expect(run, 15);
+      });
+    });
   });
 }

--- a/test/src/option_test.dart
+++ b/test/src/option_test.dart
@@ -773,6 +773,33 @@ void main() {
       expect(doOption, isA<None>());
     });
 
+    test('should rethrow if throw is used inside Option.Do', () {
+      final doOption = () => Option.Do(($) {
+            $(Option.of(10));
+            throw UnimplementedError();
+          });
+
+      expect(doOption, throwsA(const TypeMatcher<UnimplementedError>()));
+    });
+
+    test('should rethrow if None is thrown inside Option.Do', () {
+      final doOption = () => Option.Do(($) {
+            $(Option.of(10));
+            throw None();
+          });
+
+      expect(doOption, throwsA(const TypeMatcher<None>()));
+    });
+
+    test('should throw if the error is not None', () {
+      final doOption = () => Option.Do(($) {
+            $(Option.of(10));
+            throw UnimplementedError();
+          });
+
+      expect(doOption, throwsA(const TypeMatcher<UnimplementedError>()));
+    });
+
     test('should no execute past the first None', () {
       var mutable = 10;
       final doOptionNone = Option.Do(($) {

--- a/test/src/option_test.dart
+++ b/test/src/option_test.dart
@@ -772,5 +772,29 @@ void main() {
 
       expect(doOption, isA<None>());
     });
+
+    test('should no execute past the first None', () {
+      var mutable = 10;
+      final doOptionNone = Option.Do(($) {
+        final a = $(Option.of(10));
+        final b = $(Option<int>.none());
+        mutable += 10;
+        return a + b;
+      });
+
+      expect(mutable, 10);
+      expect(doOptionNone, isA<None>());
+
+      final doOptionSome = Option.Do(($) {
+        final a = $(Option.of(10));
+        mutable += 10;
+        return a;
+      });
+
+      expect(mutable, 20);
+      doOptionSome.matchTestSome((t) {
+        expect(t, 10);
+      });
+    });
   });
 }

--- a/test/src/option_test.dart
+++ b/test/src/option_test.dart
@@ -773,7 +773,7 @@ void main() {
       expect(doOption, isA<None>());
     });
 
-    test('should rethrow if throw is used inside Option.Do', () {
+    test('should rethrow if throw is used inside Do', () {
       final doOption = () => Option.Do(($) {
             $(Option.of(10));
             throw UnimplementedError();
@@ -782,7 +782,7 @@ void main() {
       expect(doOption, throwsA(const TypeMatcher<UnimplementedError>()));
     });
 
-    test('should rethrow if None is thrown inside Option.Do', () {
+    test('should rethrow if None is thrown inside Do', () {
       final doOption = () => Option.Do(($) {
             $(Option.of(10));
             throw None();

--- a/test/src/option_test.dart
+++ b/test/src/option_test.dart
@@ -742,4 +742,35 @@ void main() {
       expect(cast, isA<None>());
     });
   });
+
+  group('Do Notation', () {
+    test('should return the correct value', () {
+      final doOption = Option.Do(($) => $(Option.of(10)));
+      doOption.matchTestSome((t) {
+        expect(t, 10);
+      });
+    });
+
+    test('should extract the correct values', () {
+      final doOption = Option.Do(($) {
+        final a = $(Option.of(10));
+        final b = $(Option.of(5));
+        return a + b;
+      });
+      doOption.matchTestSome((t) {
+        expect(t, 15);
+      });
+    });
+
+    test('should return None if any Option is None', () {
+      final doOption = Option.Do(($) {
+        final a = $(Option.of(10));
+        final b = $(Option.of(5));
+        final c = $(Option<int>.none());
+        return a + b + c;
+      });
+
+      expect(doOption, isA<None>());
+    });
+  });
 }

--- a/test/src/task_either_test.dart
+++ b/test/src/task_either_test.dart
@@ -976,6 +976,25 @@ void main() {
         });
       });
 
+      test('should rethrow if throw is used inside Do', () {
+        final doTaskEither = TaskEither<String, int>.Do(($) {
+          $(TaskEither.of(10));
+          throw UnimplementedError();
+        });
+
+        expect(
+            doTaskEither.run, throwsA(const TypeMatcher<UnimplementedError>()));
+      });
+
+      test('should rethrow if Left is thrown inside Do', () {
+        final doTaskEither = TaskEither<String, int>.Do(($) {
+          $(TaskEither.of(10));
+          throw Left('Error');
+        });
+
+        expect(doTaskEither.run, throwsA(const TypeMatcher<Left>()));
+      });
+
       test('should no execute past the first Left', () async {
         var mutable = 10;
         final doTaskEitherLeft = TaskEither<String, int>.Do(($) async {

--- a/test/src/task_either_test.dart
+++ b/test/src/task_either_test.dart
@@ -940,5 +940,41 @@ void main() {
         expect(sideEffect, 11);
       });
     });
+
+    group('Do Notation', () {
+      test('should return the correct value', () async {
+        final doTaskEither =
+            TaskEither<String, int>.Do(($) => $(TaskEither.of(10)));
+        final run = await doTaskEither.run();
+        run.matchTestRight((t) {
+          expect(t, 10);
+        });
+      });
+
+      test('should extract the correct values', () async {
+        final doTaskEither = TaskEither<String, int>.Do(($) async {
+          final a = await $(TaskEither.of(10));
+          final b = await $(TaskEither.of(5));
+          return a + b;
+        });
+        final run = await doTaskEither.run();
+        run.matchTestRight((t) {
+          expect(t, 15);
+        });
+      });
+
+      test('should return Left if any Either is Left', () async {
+        final doTaskEither = TaskEither<String, int>.Do(($) async {
+          final a = await $(TaskEither.of(10));
+          final b = await $(TaskEither.of(5));
+          final c = await $(TaskEither<String, int>.left('Error'));
+          return a + b + c;
+        });
+        final run = await doTaskEither.run();
+        run.matchTestLeft((t) {
+          expect(t, 'Error');
+        });
+      });
+    });
   });
 }

--- a/test/src/task_either_test.dart
+++ b/test/src/task_either_test.dart
@@ -975,6 +975,34 @@ void main() {
           expect(t, 'Error');
         });
       });
+
+      test('should no execute past the first Left', () async {
+        var mutable = 10;
+        final doTaskEitherLeft = TaskEither<String, int>.Do(($) async {
+          final a = await $(TaskEither.of(10));
+          final b = await $(TaskEither<String, int>.left("Error"));
+          mutable += 10;
+          return a + b;
+        });
+
+        final runLeft = await doTaskEitherLeft.run();
+        expect(mutable, 10);
+        runLeft.matchTestLeft((l) {
+          expect(l, "Error");
+        });
+
+        final doTaskEitherRight = TaskEither<String, int>.Do(($) async {
+          final a = await $(TaskEither.of(10));
+          mutable += 10;
+          return a;
+        });
+
+        final runRight = await doTaskEitherRight.run();
+        expect(mutable, 20);
+        runRight.matchTestRight((t) {
+          expect(t, 10);
+        });
+      });
     });
   });
 }

--- a/test/src/task_test.dart
+++ b/test/src/task_test.dart
@@ -282,5 +282,37 @@ void main() {
       expect(result, ['10', '21', '32', '43', '54', '65']);
       expect(sideEffect, 11);
     });
+
+    group('Do Notation', () {
+      test('should return the correct value', () async {
+        final doTask = Task.Do(($) => $(Task.of(10)));
+        final run = await doTask.run();
+        expect(run, 10);
+      });
+
+      test('should extract the correct values', () async {
+        final doTask = Task.Do(($) async {
+          final a = await $(Task.of(10));
+          final b = await $(Task.of(5));
+          return a + b;
+        });
+        final run = await doTask.run();
+        expect(run, 15);
+      });
+
+      test('should not execute until run is called', () async {
+        var mutable = 10;
+        final doTask = Task.Do(($) async {
+          final a = await $(Task.of(10));
+          final b = await $(Task.of(5));
+          mutable += 10;
+          return a + b;
+        });
+        expect(mutable, 10);
+        final run = await doTask.run();
+        expect(mutable, 20);
+        expect(run, 15);
+      });
+    });
   });
 }


### PR DESCRIPTION
This PR introduces the **Do notation** in `fpdart`. This is the result of the discussion in #26.

The Do notation aims to simplify (flatten) long chains to a more readable and linear code, while still keeping the functional programming advantages and guarantees. 

Below and example of refactoring for the `Option` type:
```dart
/// Without the Do notation
String goShopping() => goToShoppingCenter()
    .alt(goToLocalMarket)
    .flatMap(
      (market) => market.buyBanana().flatMap(
            (banana) => market.buyApple().flatMap(
                  (apple) => market.buyPear().flatMap(
                        (pear) => Option.of('Shopping: $banana, $apple, $pear'),
                      ),
                ),
          ),
    )
    .getOrElse(
      () => 'I did not find 🍌 or 🍎 or 🍐, so I did not buy anything 🤷‍♂️',
    );
```

```dart
/// Using the Do notation
String goShoppingDo() => Option.Do(
      ($) {
        final market = $(goToShoppingCenter().alt(goToLocalMarket));
        final amount = $(market.buyAmount());

        final banana = $(market.buyBanana());
        final apple = $(market.buyApple());
        final pear = $(market.buyPear());

        return 'Shopping: $banana, $apple, $pear';
      },
    ).getOrElse(
      () => 'I did not find 🍌 or 🍎 or 🍐, so I did not buy anything 🤷‍♂️',
    );
```

### Status
- [x] `Option`
- [x] `Either`
- [x] `TaskEither`
- [x] `Task`
- [x] `IO`
- [x] `IOEither`
- [x] `TaskOption`

> **Note**: The Do **Notation** will be released in a beta version for testing, before landing in an official `fpdart` release. We are looking for feedback 🤝