### PR TITLE
`IO` conversions (`TaskEither`, `TaskOption`, `IOEither`)

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -30,6 +30,9 @@ class IO<A> extends HKT<_IOHKT, A>
   /// a function that returns a `Future<B>` ([Task]).
   Task<B> flatMapTask<B>(Task<B> Function(A a) f) => f(run());
 
+  /// Convert this [IO] to a [IOEither].
+  IOEither<L, A> toIOEither<L>() => IOEither<L, A>(() => Either.of(run()));
+
   /// Lift this [IO] to a [Task].
   ///
   /// Return a `Future<A>` ([Task]) instead of a `R` ([IO]).

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -33,7 +33,11 @@ class IO<A> extends HKT<_IOHKT, A>
   /// Lift this [IO] to a [Task].
   ///
   /// Return a `Future<A>` ([Task]) instead of a `R` ([IO]).
-  Task<A> toTask() => Task(() async => run());
+  Task<A> toTask() => Task<A>(() async => run());
+
+  /// Convert this [IO] to a [TaskEither].
+  TaskEither<L, A> toTaskEither<L>() =>
+      TaskEither<L, A>(() async => Either.of(run()));
 
   /// Return an [IO] that returns the value `b`.
   @override

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -39,6 +39,9 @@ class IO<A> extends HKT<_IOHKT, A>
   TaskEither<L, A> toTaskEither<L>() =>
       TaskEither<L, A>(() async => Either.of(run()));
 
+  /// Convert this [IO] to a [TaskOption].
+  TaskOption<A> toTaskOption() => TaskOption<A>(() async => Option.of(run()));
+
   /// Return an [IO] that returns the value `b`.
   @override
   IO<B> pure<B>(B b) => IO(() => b);

--- a/test/src/io_test.dart
+++ b/test/src/io_test.dart
@@ -34,6 +34,13 @@ void main() {
       expect(r, 20);
     });
 
+    test('toIOEither', () {
+      final io = IO(() => 10);
+      final ap = io.toIOEither<String>();
+      final r = ap.run();
+      r.matchTestRight((r) => expect(r, 10));
+    });
+
     test('toTask', () async {
       final io = IO(() => 10);
       final ap = io.toTask();

--- a/test/src/io_test.dart
+++ b/test/src/io_test.dart
@@ -1,5 +1,6 @@
 import 'package:fpdart/fpdart.dart';
-import 'package:test/test.dart';
+
+import 'utils/utils.dart';
 
 void main() {
   group('IO', () {
@@ -38,6 +39,13 @@ void main() {
       final ap = io.toTask();
       final r = await ap.run();
       expect(r, 10);
+    });
+
+    test('toTaskEither', () async {
+      final io = IO(() => 10);
+      final ap = io.toTaskEither<String>();
+      final r = await ap.run();
+      r.matchTestRight((r) => expect(r, 10));
     });
 
     test('ap', () {

--- a/test/src/io_test.dart
+++ b/test/src/io_test.dart
@@ -48,6 +48,13 @@ void main() {
       r.matchTestRight((r) => expect(r, 10));
     });
 
+    test('toTaskOption', () async {
+      final io = IO(() => 10);
+      final ap = io.toTaskOption();
+      final r = await ap.run();
+      r.matchTestSome((r) => expect(r, 10));
+    });
+
     test('ap', () {
       final io = IO(() => 10);
       final ap = io.ap(IO(() => (int a) => a * 3));


### PR DESCRIPTION
Added methods to convert `IO` to `TaskEither`, `TaskOption`, `IOEither`.

Closes #102 