### PR TITLE
`IOOption`

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ final flatMap = task.flatMap((a) => Task.of(a + 10));
 
 ### Utility types
 These types compose together the 4 above ([`Option`](#option), [`Either`](#either), [`IO`](#io), [`Task`](#task)) to join together their functionalities:
+- [`IOOption`](./lib/src/io_option.dart): sync function (`IO`) that may may miss the return value (`Option`)
 - [`IOEither`](./lib/src/io_either.dart): sync function (`IO`) that may fail (`Either`)
 - [`TaskOption`](./lib/src/task_option.dart): async function (`Task`) that may miss the return value (`Option`)
 - [`TaskEither`](./lib/src/task_either.dart): async function (`Task`) that may fail (`Either`)
@@ -287,7 +288,7 @@ Many more examples are coming soon. Check out [**my website**](https://www.sandr
 - [x] `IOEither`
 - [x] `TaskOption`
 - [x] `Predicate`
-- [ ] `IOOption`
+- [x] `IOOption`
 - [ ] `ReaderEither`
 - [ ] `ReaderTask`
 - [ ] `ReaderTaskEither`
@@ -299,7 +300,9 @@ Many more examples are coming soon. Check out [**my website**](https://www.sandr
 
 Functional programming is becoming more and more popular, and for good reasons.
 
-Many non-functional languages are slowly adopting patterns from functional languages, dart included. Dart already supports higher-order functions, generic types, type inference. Other functional programming features are coming to the language, like [pattern matching](https://github.com/dart-lang/language/issues/546), [destructuring](https://github.com/dart-lang/language/issues/207), [multiple return values](https://github.com/dart-lang/language/issues/68), [higher-order types](https://github.com/dart-lang/language/issues/1655).
+Many non-functional languages are slowly adopting patterns from functional languages, dart included. Dart already supports higher-order functions, generic types, type inference. Since Dart 3, the language supports also [pattern matching](https://github.com/dart-lang/language/issues/546), [destructuring](https://github.com/dart-lang/language/issues/207), [multiple return values](https://github.com/dart-lang/language/issues/68) ([**Read more about these new features here**](https://www.sandromaglione.com/techblog/records-and-patterns-dart-language)).
+
+Other functional programming features are coming to the language, like [higher-order types](https://github.com/dart-lang/language/issues/1655).
 
 Many packages are bringing functional patterns to dart, like the amazing [freezed](https://pub.dev/packages/freezed) for unions/pattern matching.
 
@@ -337,13 +340,12 @@ Being documentation and stability important goals of the package, every type wil
 
 The roadmap for types development is highlighted below (breaking changes to _'stable'_ types are to be expected in this early stages):
 
-1. `IOOption`
-2. `ReaderEither`
-3. `ReaderTask`
-4. `ReaderTaskEither`
-5. `StateReaderTaskEither`
-6. `Writer`
-7. `Lens`
+1. `ReaderEither`
+2. `ReaderTask`
+3. `ReaderTaskEither`
+4. `StateReaderTaskEither`
+5. `Writer`
+6. `Lens`
 
 ***
 

--- a/lib/fpdart.dart
+++ b/lib/fpdart.dart
@@ -5,6 +5,7 @@ export 'src/either.dart';
 export 'src/function.dart';
 export 'src/io.dart';
 export 'src/io_either.dart';
+export 'src/io_option.dart';
 export 'src/io_ref.dart';
 export 'src/list_extension.dart';
 export 'src/map_extension.dart';

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -45,6 +45,9 @@ class IO<A> extends HKT<_IOHKT, A>
   /// Convert this [IO] to a [TaskOption].
   TaskOption<A> toTaskOption() => TaskOption<A>(() async => Option.of(run()));
 
+  /// Convert this [IO] to a [IOOption].
+  IOOption<A> toIOOption() => IOOption<A>(() => Option.of(run()));
+
   /// Return an [IO] that returns the value `b`.
   @override
   IO<B> pure<B>(B b) => IO(() => b);

--- a/lib/src/io_either.dart
+++ b/lib/src/io_either.dart
@@ -60,6 +60,9 @@ class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
   /// a `Either<L, R>` ([IOEither]).
   TaskEither<L, R> toTask() => TaskEither(() async => run());
 
+  /// Convert this [IOEither] to [TaskEither].
+  TaskEither<L, R> toTaskEither() => TaskEither(() async => run());
+
   /// Returns a [IOEither] that returns a `Right(a)`.
   @override
   IOEither<L, C> pure<C>(C a) => IOEither(() => Right(a));

--- a/lib/src/io_either.dart
+++ b/lib/src/io_either.dart
@@ -54,12 +54,6 @@ class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
         ),
       );
 
-  /// Lift this [IOEither] to a [TaskEither].
-  ///
-  /// Return a `Future<Either<L, R>>` ([TaskEither]) instead of
-  /// a `Either<L, R>` ([IOEither]).
-  TaskEither<L, R> toTask() => TaskEither(() async => run());
-
   /// Convert this [IOEither] to [TaskEither].
   TaskEither<L, R> toTaskEither() => TaskEither(() async => run());
 

--- a/lib/src/io_option.dart
+++ b/lib/src/io_option.dart
@@ -1,0 +1,216 @@
+import 'either.dart';
+import 'function.dart';
+import 'io.dart';
+import 'option.dart';
+import 'typeclass/alt.dart';
+import 'typeclass/applicative.dart';
+import 'typeclass/functor.dart';
+import 'typeclass/hkt.dart';
+import 'typeclass/monad.dart';
+
+/// Tag the [HKT] interface for the actual [IOOption].
+abstract class _IOOptionHKT {}
+
+/// `IOOption<R>` represents an **synchronous** computation that
+/// may fails yielding a [None] or returns a `Some(R)` when successful.
+///
+/// If you want to represent an synchronous computation that never fails, see [IO].
+///
+/// If you want to represent an synchronous computation that returns an object when it fails,
+/// see [IOEither].
+class IOOption<R> extends HKT<_IOOptionHKT, R>
+    with
+        Functor<_IOOptionHKT, R>,
+        Applicative<_IOOptionHKT, R>,
+        Monad<_IOOptionHKT, R>,
+        Alt<_IOOptionHKT, R> {
+  final Option<R> Function() _run;
+
+  /// Build a [IOOption] from a function returning a `Option<R>`.
+  const IOOption(this._run);
+
+  /// Used to chain multiple functions that return a [IOOption].
+  ///
+  /// You can extract the value of every [Some] in the chain without
+  /// handling all possible missing cases.
+  /// If running any of the functions in the chain returns [None], the result is [None].
+  @override
+  IOOption<C> flatMap<C>(covariant IOOption<C> Function(R r) f) =>
+      IOOption(() => run().match(
+            Option.none,
+            (r) => f(r).run(),
+          ));
+
+  /// Returns a [IOOption] that returns `Some(c)`.
+  @override
+  IOOption<C> pure<C>(C c) => IOOption(() => Option.of(c));
+
+  /// Change the return type of this [IOOption] based on its value of type `R` and the
+  /// value of type `C` of another [IOOption].
+  @override
+  IOOption<D> map2<C, D>(covariant IOOption<C> m1, D Function(R b, C c) f) =>
+      flatMap((b) => m1.map((c) => f(b, c)));
+
+  /// Change the return type of this [IOOption] based on its value of type `R`, the
+  /// value of type `C` of a second [IOOption], and the value of type `D`
+  /// of a third [IOOption].
+  @override
+  IOOption<E> map3<C, D, E>(covariant IOOption<C> m1, covariant IOOption<D> m2,
+          E Function(R b, C c, D d) f) =>
+      flatMap((b) => m1.flatMap((c) => m2.map((d) => f(b, c, d))));
+
+  /// If running this [IOOption] returns [Some], then return the result of calling `then`.
+  /// Otherwise return [None].
+  @override
+  IOOption<C> andThen<C>(covariant IOOption<C> Function() then) =>
+      flatMap((_) => then());
+
+  /// Chain multiple [IOOption] functions.
+  @override
+  IOOption<B> call<B>(covariant IOOption<B> chain) => flatMap((_) => chain);
+
+  /// If running this [IOOption] returns [Some], then change its value from type `R` to
+  /// type `C` using function `f`.
+  @override
+  IOOption<C> map<C>(C Function(R r) f) => ap(pure(f));
+
+  /// Apply the function contained inside `a` to change the value on the [Some] from
+  /// type `R` to a value of type `C`.
+  @override
+  IOOption<C> ap<C>(covariant IOOption<C Function(R r)> a) =>
+      a.flatMap((f) => flatMap((v) => pure(f(v))));
+
+  /// When this [IOOption] returns [Some], then return the current [IOOption].
+  /// Otherwise return the result of `orElse`.
+  ///
+  /// Used to provide an **alt**ernative [IOOption] in case the current one returns [None].
+  @override
+  IOOption<R> alt(covariant IOOption<R> Function() orElse) =>
+      IOOption(() => run().match(
+            () => orElse().run(),
+            some,
+          ));
+
+  /// When this [IOOption] returns a [None] then return the result of `orElse`.
+  /// Otherwise return this [IOOption].
+  IOOption<R> orElse<TL>(IOOption<R> Function() orElse) =>
+      IOOption(() => run().match(
+            () => orElse().run(),
+            (r) => IOOption<R>.some(r).run(),
+          ));
+
+  /// Extract the result of this [IOOption] into a [IO].
+  ///
+  /// The IO returns a [Some] when [IOOption] returns [Some].
+  /// Otherwise map the type `L` of [IOOption] to type `R` by calling `orElse`.
+  IO<R> getOrElse(R Function() orElse) => IO(() => run().match(
+        orElse,
+        identity,
+      ));
+
+  /// Pattern matching to convert a [IOOption] to a [IO].
+  ///
+  /// Execute `onNone` when running this [IOOption] returns a [None].
+  /// Otherwise execute `onSome`.
+  IO<A> match<A>(A Function() onNone, A Function(R r) onSome) =>
+      IO(() => run().match(
+            onNone,
+            onSome,
+          ));
+
+  /// Run the IO and return a `Option<R>`.
+  Option<R> run() => _run();
+
+  /// Build a [IOOption] that returns a `Some(r)`.
+  ///
+  /// Same of `IOOption.some`.
+  factory IOOption.of(R r) => IOOption(() => Option.of(r));
+
+  /// Flat a [IOOption] contained inside another [IOOption] to be a single [IOOption].
+  factory IOOption.flatten(IOOption<IOOption<R>> ioOption) =>
+      ioOption.flatMap(identity);
+
+  /// Build a [IOOption] that returns a `Some(r)`.
+  ///
+  /// Same of `IOOption.of`.
+  factory IOOption.some(R r) => IOOption(() => Option.of(r));
+
+  /// Build a [IOOption] that returns a [None].
+  factory IOOption.none() => IOOption(() => const Option.none());
+
+  /// If `r` is `null`, then return [None].
+  /// Otherwise return `Right(r)`.
+  factory IOOption.fromNullable(R? r) => Option.fromNullable(r).toIOOption();
+
+  /// When calling `predicate` with `value` returns `true`, then running [IOOption] returns `Some(value)`.
+  /// Otherwise return [None].
+  factory IOOption.fromPredicate(R value, bool Function(R a) predicate) =>
+      IOOption(
+        () => predicate(value) ? Option.of(value) : const Option.none(),
+      );
+
+  /// Converts a function that may throw to a function that never throws
+  /// but returns a [Option] instead.
+  ///
+  /// Used to handle synchronous computations that may throw using [Option].
+  factory IOOption.tryCatch(R Function() run) => IOOption<R>(() {
+        try {
+          return Option.of(run());
+        } catch (_) {
+          return const Option.none();
+        }
+      });
+
+  /// {@template fpdart_traverse_list_io_option}
+  /// Map each element in the list to a [IOOption] using the function `f`,
+  /// and collect the result in an `IOOption<List<B>>`.
+  /// {@endtemplate}
+  ///
+  /// Same as `IOOption.traverseList` but passing `index` in the map function.
+  static IOOption<List<B>> traverseListWithIndex<A, B>(
+    List<A> list,
+    IOOption<B> Function(A a, int i) f,
+  ) =>
+      IOOption<List<B>>(
+        () => Option.sequenceList(
+          IO
+              .traverseListWithIndex<A, Option<B>>(
+                list,
+                (a, i) => IO(() => f(a, i).run()),
+              )
+              .run(),
+        ),
+      );
+
+  /// {@macro fpdart_traverse_list_io_option}
+  ///
+  /// Same as `IOOption.traverseListWithIndex` but without `index` in the map function.
+  static IOOption<List<B>> traverseList<A, B>(
+    List<A> list,
+    IOOption<B> Function(A a) f,
+  ) =>
+      traverseListWithIndex<A, B>(list, (a, _) => f(a));
+
+  /// {@template fpdart_sequence_list_io_option}
+  /// Convert a `List<IOOption<A>>` to a single `IOOption<List<A>>`.
+  /// {@endtemplate}
+  static IOOption<List<A>> sequenceList<A>(
+    List<IOOption<A>> list,
+  ) =>
+      traverseList(list, identity);
+
+  /// Build a [IOOption] from `either` that returns [None] when
+  /// `either` is [Left], otherwise it returns [Some].
+  static IOOption<R> fromEither<L, R>(Either<L, R> either) =>
+      IOOption(() => either.match((_) => const Option.none(), some));
+
+  /// Converts a function that may throw to a function that never throws
+  /// but returns a [Option] instead.
+  ///
+  /// Used to handle synchronous computations that may throw using [Option].
+  ///
+  /// It wraps the `IOOption.tryCatch` factory to make chaining with `flatMap`
+  /// easier.
+  static IOOption<R> Function(A a) tryCatchK<R, A>(R Function(A a) run) =>
+      (a) => IOOption.tryCatch(() => run(a));
+}

--- a/lib/src/io_option.dart
+++ b/lib/src/io_option.dart
@@ -1,7 +1,10 @@
 import 'either.dart';
 import 'function.dart';
 import 'io.dart';
+import 'io_either.dart';
 import 'option.dart';
+import 'task_either.dart';
+import 'task_option.dart';
 import 'typeclass/alt.dart';
 import 'typeclass/applicative.dart';
 import 'typeclass/functor.dart';
@@ -120,6 +123,23 @@ class IOOption<R> extends HKT<_IOOptionHKT, R>
 
   /// Run the IO and return a `Option<R>`.
   Option<R> run() => _run();
+
+  /// Convert this [IOOption] to [IOEither].
+  ///
+  /// If the value inside [IOOption] is [None], then use `onNone` to convert it
+  /// to a value of type `L`.
+  IOEither<L, R> toIOEither<L>(L Function() onNone) =>
+      IOEither(() => Either.fromOption(run(), onNone));
+
+  /// Convert this [IOOption] to [TaskOption].
+  TaskOption<R> toTaskOption<L>() => TaskOption(() async => run());
+
+  /// Convert this [IOOption] to [TaskEither].
+  ///
+  /// If the value inside [IOOption] is [None], then use `onNone` to convert it
+  /// to a value of type `L`.
+  TaskEither<L, R> toTaskEither<L>(L Function() onNone) =>
+      TaskEither(() async => Either.fromOption(run(), onNone));
 
   /// Build a [IOOption] that returns a `Some(r)`.
   ///

--- a/lib/src/list_extension.dart
+++ b/lib/src/list_extension.dart
@@ -2,6 +2,7 @@ import 'date.dart';
 import 'either.dart';
 import 'io.dart';
 import 'io_either.dart';
+import 'io_option.dart';
 import 'option.dart';
 import 'task.dart';
 import 'task_either.dart';
@@ -366,6 +367,18 @@ extension FpdartTraversableIterable<T> on Iterable<T> {
   ) =>
       Option.traverseList(toList(), f);
 
+  /// {@macro fpdart_traverse_list_io_option}
+  IOOption<List<B>> traverseIOOptionWithIndex<B>(
+    IOOption<B> Function(T a, int i) f,
+  ) =>
+      IOOption.traverseListWithIndex(toList(), f);
+
+  /// {@macro fpdart_traverse_list_io_option}
+  IOOption<List<B>> traverseIOOption<B>(
+    IOOption<B> Function(T a) f,
+  ) =>
+      IOOption.traverseList(toList(), f);
+
   /// {@macro fpdart_traverse_list_task_option}
   TaskOption<List<B>> traverseTaskOptionWithIndex<B>(
     TaskOption<B> Function(T a, int i) f,
@@ -478,6 +491,11 @@ extension FpdartTraversableIterable<T> on Iterable<T> {
 extension FpdartSequenceIterableOption<T> on Iterable<Option<T>> {
   /// {@macro fpdart_sequence_list_option}
   Option<List<T>> sequenceOption() => Option.sequenceList(toList());
+}
+
+extension FpdartSequenceIterableIOOption<T> on Iterable<IOOption<T>> {
+  /// {@macro fpdart_sequence_list_io_option}
+  IOOption<List<T>> sequenceIOOption() => IOOption.sequenceList(toList());
 }
 
 extension FpdartSequenceIterableTaskOption<T> on Iterable<TaskOption<T>> {

--- a/lib/src/nullable_extension.dart
+++ b/lib/src/nullable_extension.dart
@@ -1,5 +1,6 @@
 import 'either.dart';
 import 'io_either.dart';
+import 'io_option.dart';
 import 'option.dart';
 import 'task.dart';
 import 'task_either.dart';
@@ -21,6 +22,10 @@ extension FpdartOnNullable<T> on T? {
   /// {@endtemplate}
   Either<L, T> toEither<L>(L Function() onNull) =>
       Either.fromNullable(this, onNull);
+
+  /// Convert a nullable type `T?` to [IOOption]:
+  /// {@macro fpdart_on_nullable_to_option}
+  IOOption<T> toIOOption() => IOOption.fromNullable(this);
 
   /// Convert a nullable type `T?` to [TaskOption]:
   /// {@macro fpdart_on_nullable_to_option}

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -1,5 +1,6 @@
 import 'either.dart';
 import 'function.dart';
+import 'io_option.dart';
 import 'task_option.dart';
 import 'tuple.dart';
 import 'typeclass/applicative.dart';
@@ -284,6 +285,9 @@ abstract class Option<T> extends HKT<_OptionHKT, T>
         () => Left(onLeft()),
         Right.new,
       );
+
+  /// Convert this [Option] to a [IOOption].
+  IOOption<T> toIOOption() => IOOption(() => this);
 
   /// Convert this [Option] to a [TaskOption].
   ///

--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -1,4 +1,13 @@
-import 'package:fpdart/fpdart.dart';
+import 'either.dart';
+import 'function.dart';
+import 'list_extension.dart';
+import 'option.dart';
+import 'task_either.dart';
+import 'task_option.dart';
+import 'typeclass/applicative.dart';
+import 'typeclass/functor.dart';
+import 'typeclass/hkt.dart';
+import 'typeclass/monad.dart';
 
 /// Tag the [HKT] interface for the actual [Task].
 abstract class _TaskHKT {}
@@ -73,6 +82,14 @@ class Task<A> extends HKT<_TaskHKT, A>
 
   /// Run the task and return a [Future].
   Future<A> run() => _run();
+
+  /// Convert this [Task] to [TaskOption].
+  TaskOption<A> toTaskOption() =>
+      TaskOption(() async => Option.of(await run()));
+
+  /// Convert this [Task] to [TaskEither].
+  TaskEither<L, A> toTaskEither<L>() =>
+      TaskEither<L, A>(() async => Either.of(await run()));
 
   /// {@template fpdart_traverse_list_task}
   /// Map each element in the list to a [Task] using the function `f`,

--- a/lib/src/task_option.dart
+++ b/lib/src/task_option.dart
@@ -11,7 +11,7 @@ import 'typeclass/monad.dart';
 /// Tag the [HKT] interface for the actual [TaskOption].
 abstract class _TaskOptionHKT {}
 
-/// `TaskOption<R>` represents an asynchronous computation that
+/// `TaskOption<R>` represents an **asynchronous** computation that
 /// may fails yielding a [None] or returns a `Some(R)` when successful.
 ///
 /// If you want to represent an asynchronous computation that never fails, see [Task].

--- a/lib/src/task_option.dart
+++ b/lib/src/task_option.dart
@@ -1,12 +1,4 @@
-import 'either.dart';
-import 'function.dart';
-import 'option.dart';
-import 'task.dart';
-import 'typeclass/alt.dart';
-import 'typeclass/applicative.dart';
-import 'typeclass/functor.dart';
-import 'typeclass/hkt.dart';
-import 'typeclass/monad.dart';
+import 'package:fpdart/fpdart.dart';
 
 /// Tag the [HKT] interface for the actual [TaskOption].
 abstract class _TaskOptionHKT {}
@@ -128,6 +120,13 @@ class TaskOption<R> extends HKT<_TaskOptionHKT, R>
 
   /// Run the task and return a `Future<Option<R>>`.
   Future<Option<R>> run() => _run();
+
+  /// Convert this [TaskOption] to [TaskEither].
+  ///
+  /// If the value inside [TaskOption] is [None], then use `onNone` to convert it
+  /// to a value of type `L`.
+  TaskEither<L, R> toTaskEither<L>(L Function() onNone) =>
+      TaskEither(() async => Either.fromOption(await run(), onNone));
 
   /// Build a [TaskOption] that returns a `Some(r)`.
   ///

--- a/test/src/io_either_test.dart
+++ b/test/src/io_either_test.dart
@@ -120,6 +120,26 @@ void main() {
       });
     });
 
+    group('toTaskEither', () {
+      test('Some', () async {
+        final task = IOEither(() => Either.of(10));
+        final convert = task.toTaskEither();
+        final r = await convert.run();
+        r.matchTestRight((r) {
+          expect(r, 10);
+        });
+      });
+
+      test('None', () async {
+        final task = IOEither(() => Either.left('None'));
+        final convert = task.toTaskEither();
+        final r = await convert.run();
+        r.matchTestLeft((l) {
+          expect(l, 'None');
+        });
+      });
+    });
+
     group('ap', () {
       test('Right', () {
         final task = IOEither<String, int>(() => Either.of(10));

--- a/test/src/io_either_test.dart
+++ b/test/src/io_either_test.dart
@@ -100,26 +100,6 @@ void main() {
       });
     });
 
-    group('toTask', () {
-      test('Right', () async {
-        final task = IOEither<String, int>(() => Either.of(10));
-        final ap = task.toTask();
-        final r = await ap.run();
-        r.match((_) {
-          fail('should be right');
-        }, (r) => expect(r, 10));
-      });
-
-      test('Left', () async {
-        final task = IOEither<String, int>(() => Either.left('abc'));
-        final ap = task.toTask();
-        final r = await ap.run();
-        r.match((l) => expect(l, 'abc'), (_) {
-          fail('should be left');
-        });
-      });
-    });
-
     group('toTaskEither', () {
       test('Some', () async {
         final task = IOEither(() => Either.of(10));

--- a/test/src/io_option_test.dart
+++ b/test/src/io_option_test.dart
@@ -302,6 +302,64 @@ void main() {
       r.matchTestSome((r) => expect(r, 10));
     });
 
+    group('toTaskOption', () {
+      test('Some', () async {
+        final io = IOOption(() => Option.of(10));
+        final convert = io.toTaskOption();
+        final r = await convert.run();
+        r.matchTestSome((r) {
+          expect(r, 10);
+        });
+      });
+
+      test('None', () async {
+        final io = IOOption(() => const Option.none());
+        final convert = io.toTaskOption();
+        final r = await convert.run();
+        expect(r, isA<None>());
+      });
+    });
+
+    group('toOptionEither', () {
+      test('Some', () {
+        final io = IOOption(() => Option.of(10));
+        final convert = io.toIOEither(() => 'None');
+        final r = convert.run();
+        r.matchTestRight((r) {
+          expect(r, 10);
+        });
+      });
+
+      test('None', () {
+        final io = IOOption(() => const Option.none());
+        final convert = io.toIOEither(() => 'None');
+        final r = convert.run();
+        r.matchTestLeft((l) {
+          expect(l, 'None');
+        });
+      });
+    });
+
+    group('toTaskEither', () {
+      test('Some', () async {
+        final io = IOOption(() => Option.of(10));
+        final convert = io.toTaskEither(() => 'None');
+        final r = await convert.run();
+        r.matchTestRight((r) {
+          expect(r, 10);
+        });
+      });
+
+      test('None', () async {
+        final io = IOOption(() => const Option.none());
+        final convert = io.toTaskEither(() => 'None');
+        final r = await convert.run();
+        r.matchTestLeft((l) {
+          expect(l, 'None');
+        });
+      });
+    });
+
     group('sequenceList', () {
       test('Some', () {
         var sideEffect = 0;

--- a/test/src/io_option_test.dart
+++ b/test/src/io_option_test.dart
@@ -1,0 +1,443 @@
+import 'package:fpdart/fpdart.dart';
+
+import './utils/utils.dart';
+
+void main() {
+  group('IOOption', () {
+    group('tryCatch', () {
+      test('Success', () {
+        final io = IOOption<int>.tryCatch(() => 10);
+        final r = io.run();
+        r.matchTestSome((r) => expect(r, 10));
+      });
+
+      test('throws Exception', () {
+        final io = IOOption<int>.tryCatch(() {
+          throw UnimplementedError();
+        });
+        final r = io.run();
+        expect(r, isA<None>());
+      });
+    });
+
+    group('tryCatchK', () {
+      test('Success', () {
+        final io = IOOption<int>.of(10);
+        final ap = io.flatMap(IOOption.tryCatchK(
+          (n) => n + 5,
+        ));
+        final r = ap.run();
+        r.matchTestSome((r) => expect(r, 15));
+      });
+
+      test('throws Exception', () {
+        final io = IOOption<int>.of(10);
+        final ap = io.flatMap(IOOption.tryCatchK<int, int>((_) {
+          throw UnimplementedError();
+        }));
+        final r = ap.run();
+        expect(r, isA<None>());
+      });
+    });
+
+    group('flatMap', () {
+      test('Some', () {
+        final io = IOOption<int>(() => Option.of(10));
+        final ap = io.flatMap((r) => IOOption<int>(() => Option.of(r + 10)));
+        final r = ap.run();
+        r.matchTestSome((r) => expect(r, 20));
+      });
+
+      test('None', () {
+        final io = IOOption<int>(() => Option.none());
+        final ap = io.flatMap((r) => IOOption<int>(() => Option.of(r + 10)));
+        final r = ap.run();
+        expect(r, isA<None>());
+      });
+    });
+
+    group('ap', () {
+      test('Some', () {
+        final io = IOOption<int>(() => Option.of(10));
+        final ap = io.ap<double>(IOOption(() => Option.of((int c) => c / 2)));
+        final r = ap.run();
+        r.matchTestSome((r) => expect(r, 5.0));
+      });
+
+      test('None', () {
+        final io = IOOption<int>(() => Option.none());
+        final ap = io.ap<double>(IOOption(() => Option.of((int c) => c / 2)));
+        final r = ap.run();
+        expect(r, isA<None>());
+      });
+    });
+
+    group('map', () {
+      test('Some', () {
+        final io = IOOption<int>(() => Option.of(10));
+        final ap = io.map((r) => r / 2);
+        final r = ap.run();
+        r.matchTestSome((r) => expect(r, 5.0));
+      });
+
+      test('None', () {
+        final io = IOOption<int>(() => Option.none());
+        final ap = io.map((r) => r / 2);
+        final r = ap.run();
+        expect(r, isA<None>());
+      });
+    });
+
+    group('map2', () {
+      test('Some', () {
+        final io = IOOption<int>(() => Option.of(10));
+        final ap = io.map2<int, double>(
+            IOOption<int>(() => Option.of(2)), (b, c) => b / c);
+        final r = ap.run();
+        r.matchTestSome((r) => expect(r, 5.0));
+      });
+
+      test('None', () {
+        final io = IOOption<int>(() => Option.none());
+        final ap = io.map2<int, double>(
+            IOOption<int>(() => Option.of(2)), (b, c) => b / c);
+        final r = ap.run();
+        expect(r, isA<None>());
+      });
+    });
+
+    group('map3', () {
+      test('Some', () {
+        final io = IOOption<int>(() => Option.of(10));
+        final ap = io.map3<int, int, double>(IOOption<int>(() => Option.of(2)),
+            IOOption<int>(() => Option.of(5)), (b, c, d) => b * c / d);
+        final r = ap.run();
+        r.matchTestSome((r) => expect(r, 4.0));
+      });
+
+      test('None', () {
+        final io = IOOption<int>(() => Option.none());
+        final ap = io.map3<int, int, double>(IOOption<int>(() => Option.of(2)),
+            IOOption<int>(() => Option.of(5)), (b, c, d) => b * c / d);
+        final r = ap.run();
+        expect(r, isA<None>());
+      });
+    });
+
+    group('andThen', () {
+      test('Some', () {
+        final io = IOOption<int>(() => Option.of(10));
+        final ap = io.andThen(() => IOOption<double>(() => Option.of(12.5)));
+        final r = ap.run();
+        r.matchTestSome((r) => expect(r, 12.5));
+      });
+
+      test('None', () {
+        final io = IOOption<int>(() => Option.none());
+        final ap = io.andThen(() => IOOption<double>(() => Option.of(12.5)));
+        final r = ap.run();
+        expect(r, isA<None>());
+      });
+    });
+
+    group('call', () {
+      test('Some', () {
+        final io = IOOption<int>(() => Option.of(10));
+        final ap = io(IOOption<double>(() => Option.of(12.5)));
+        final r = ap.run();
+        r.matchTestSome((r) => expect(r, 12.5));
+      });
+
+      test('None', () {
+        final io = IOOption<int>(() => Option.none());
+        final ap = io(IOOption<double>(() => Option.of(12.5)));
+        final r = ap.run();
+        expect(r, isA<None>());
+      });
+    });
+
+    test('pure', () {
+      final io = IOOption<int>(() => Option.none());
+      final ap = io.pure('abc');
+      final r = ap.run();
+      r.matchTestSome((r) => expect(r, 'abc'));
+    });
+
+    test('run', () {
+      final io = IOOption<int>(() => Option.of(10));
+      final r = io.run();
+      r.matchTestSome((r) => expect(r, 10));
+    });
+
+    group('fromEither', () {
+      test('Some', () {
+        final io = IOOption.fromEither<String, int>(Either.of(10));
+        final r = io.run();
+        r.matchTestSome((r) => expect(r, 10));
+      });
+
+      test('None', () {
+        final io = IOOption.fromEither<String, int>(Either.left('none'));
+        final r = io.run();
+        expect(r, isA<None>());
+      });
+    });
+
+    group('fromNullable', () {
+      test('Right', () {
+        final io = IOOption<int>.fromNullable(10);
+        final result = io.run();
+        result.matchTestSome((r) {
+          expect(r, 10);
+        });
+      });
+
+      test('Left', () {
+        final io = IOOption<int>.fromNullable(null);
+        final result = io.run();
+        expect(result, isA<None>());
+      });
+    });
+
+    group('fromPredicate', () {
+      test('True', () {
+        final io = IOOption<int>.fromPredicate(20, (n) => n > 10);
+        final r = io.run();
+        r.matchTestSome((r) => expect(r, 20));
+      });
+
+      test('False', () {
+        final io = IOOption<int>.fromPredicate(10, (n) => n > 10);
+        final r = io.run();
+        expect(r, isA<None>());
+      });
+    });
+
+    test('none()', () {
+      final io = IOOption<int>.none();
+      final r = io.run();
+      expect(r, isA<None>());
+    });
+
+    test('some()', () {
+      final io = IOOption<int>.some(10);
+      final r = io.run();
+      r.matchTestSome((r) => expect(r, 10));
+    });
+
+    group('match', () {
+      test('Some', () {
+        final io = IOOption<int>(() => Option.of(10));
+        final ex = io.match(() => -1, (r) => r + 10);
+        final r = ex.run();
+        expect(r, 20);
+      });
+
+      test('None', () {
+        final io = IOOption<int>(() => Option.none());
+        final ex = io.match(() => -1, (r) => r + 10);
+        final r = ex.run();
+        expect(r, -1);
+      });
+    });
+
+    group('getOrElse', () {
+      test('Some', () {
+        final io = IOOption<int>(() => Option.of(10));
+        final ex = io.getOrElse(() => -1);
+        final r = ex.run();
+        expect(r, 10);
+      });
+
+      test('None', () {
+        final io = IOOption<int>(() => Option.none());
+        final ex = io.getOrElse(() => -1);
+        final r = ex.run();
+        expect(r, -1);
+      });
+    });
+
+    group('orElse', () {
+      test('Some', () {
+        final io = IOOption<int>(() => Option.of(10));
+        final ex = io.orElse<int>(() => IOOption(() => Option.of(-1)));
+        final r = ex.run();
+        r.matchTestSome((r) => expect(r, 10));
+      });
+
+      test('None', () {
+        final io = IOOption<int>(() => Option.none());
+        final ex = io.orElse<int>(() => IOOption(() => Option.of(-1)));
+        final r = ex.run();
+        r.matchTestSome((r) => expect(r, -1));
+      });
+    });
+
+    group('alt', () {
+      test('Some', () {
+        final io = IOOption<int>(() => Option.of(10));
+        final ex = io.alt(() => IOOption(() => Option.of(20)));
+        final r = ex.run();
+        r.matchTestSome((r) => expect(r, 10));
+      });
+
+      test('None', () {
+        final io = IOOption<int>(() => Option.none());
+        final ex = io.alt(() => IOOption(() => Option.of(20)));
+        final r = ex.run();
+        r.matchTestSome((r) => expect(r, 20));
+      });
+    });
+
+    test('of', () {
+      final io = IOOption<int>.of(10);
+      final r = io.run();
+      r.matchTestSome((r) => expect(r, 10));
+    });
+
+    test('flatten', () {
+      final io = IOOption<IOOption<int>>.of(IOOption<int>.of(10));
+      final ap = IOOption.flatten(io);
+      final r = ap.run();
+      r.matchTestSome((r) => expect(r, 10));
+    });
+
+    group('sequenceList', () {
+      test('Some', () {
+        var sideEffect = 0;
+        final list = [
+          IOOption(() {
+            sideEffect += 1;
+            return some(1);
+          }),
+          IOOption(() {
+            sideEffect += 1;
+            return some(2);
+          }),
+          IOOption(() {
+            sideEffect += 1;
+            return some(3);
+          }),
+          IOOption(() {
+            sideEffect += 1;
+            return some(4);
+          }),
+        ];
+        final traverse = IOOption.sequenceList(list);
+        expect(sideEffect, 0);
+        final result = traverse.run();
+        result.matchTestSome((t) {
+          expect(t, [1, 2, 3, 4]);
+        });
+        expect(sideEffect, list.length);
+      });
+
+      test('None', () {
+        var sideEffect = 0;
+        final list = [
+          IOOption(() {
+            sideEffect += 1;
+            return some(1);
+          }),
+          IOOption(() {
+            sideEffect += 1;
+            return none<int>();
+          }),
+          IOOption(() {
+            sideEffect += 1;
+            return some(3);
+          }),
+          IOOption(() {
+            sideEffect += 1;
+            return some(4);
+          }),
+        ];
+        final traverse = IOOption.sequenceList(list);
+        expect(sideEffect, 0);
+        final result = traverse.run();
+        expect(result, isA<None>());
+        expect(sideEffect, list.length);
+      });
+    });
+
+    group('traverseList', () {
+      test('Some', () {
+        final list = [1, 2, 3, 4, 5, 6];
+        var sideEffect = 0;
+        final traverse = IOOption.traverseList<int, String>(
+          list,
+          (a) => IOOption(
+            () {
+              sideEffect += 1;
+              return some("$a");
+            },
+          ),
+        );
+        expect(sideEffect, 0);
+        final result = traverse.run();
+        result.matchTestSome((t) {
+          expect(t, ['1', '2', '3', '4', '5', '6']);
+        });
+        expect(sideEffect, list.length);
+      });
+
+      test('None', () {
+        final list = [1, 2, 3, 4, 5, 6];
+        var sideEffect = 0;
+        final traverse = IOOption.traverseList<int, String>(
+          list,
+          (a) => IOOption(
+            () {
+              sideEffect += 1;
+              return a % 2 == 0 ? some("$a") : none();
+            },
+          ),
+        );
+        expect(sideEffect, 0);
+        final result = traverse.run();
+        expect(result, isA<None>());
+        expect(sideEffect, list.length);
+      });
+    });
+
+    group('traverseListWithIndex', () {
+      test('Some', () {
+        final list = [1, 2, 3, 4, 5, 6];
+        var sideEffect = 0;
+        final traverse = IOOption.traverseListWithIndex<int, String>(
+          list,
+          (a, i) => IOOption(
+            () {
+              sideEffect += 1;
+              return some("$a$i");
+            },
+          ),
+        );
+        expect(sideEffect, 0);
+        final result = traverse.run();
+        result.matchTestSome((t) {
+          expect(t, ['10', '21', '32', '43', '54', '65']);
+        });
+        expect(sideEffect, list.length);
+      });
+
+      test('None', () {
+        final list = [1, 2, 3, 4, 5, 6];
+        var sideEffect = 0;
+        final traverse = IOOption.traverseListWithIndex<int, String>(
+          list,
+          (a, i) => IOOption(
+            () {
+              sideEffect += 1;
+              return a % 2 == 0 ? some("$a$i") : none();
+            },
+          ),
+        );
+        expect(sideEffect, 0);
+        final result = traverse.run();
+        expect(result, isA<None>());
+        expect(sideEffect, list.length);
+      });
+    });
+  });
+}

--- a/test/src/io_test.dart
+++ b/test/src/io_test.dart
@@ -62,6 +62,13 @@ void main() {
       r.matchTestSome((r) => expect(r, 10));
     });
 
+    test('toIOOption', () {
+      final io = IO(() => 10);
+      final ap = io.toIOOption();
+      final r = ap.run();
+      r.matchTestSome((r) => expect(r, 10));
+    });
+
     test('ap', () {
       final io = IO(() => 10);
       final ap = io.ap(IO(() => (int a) => a * 3));

--- a/test/src/list_extension_test.dart
+++ b/test/src/list_extension_test.dart
@@ -653,6 +653,84 @@ void main() {
       expect(sideEffect, 11);
     });
 
+    group('traverseIOOption', () {
+      test('Some', () {
+        final list = [1, 2, 3, 4, 5, 6];
+        var sideEffect = 0;
+        final traverse = list.traverseIOOption<String>(
+          (a) => IOOption(
+            () {
+              sideEffect += 1;
+              return some("$a");
+            },
+          ),
+        );
+        expect(sideEffect, 0);
+        final result = traverse.run();
+        result.matchTestSome((t) {
+          expect(t, ['1', '2', '3', '4', '5', '6']);
+        });
+        expect(sideEffect, list.length);
+      });
+
+      test('None', () {
+        final list = [1, 2, 3, 4, 5, 6];
+        var sideEffect = 0;
+        final traverse = list.traverseIOOption<String>(
+          (a) => IOOption(
+            () {
+              sideEffect += 1;
+              return a % 2 == 0 ? some("$a") : none();
+            },
+          ),
+        );
+        expect(sideEffect, 0);
+        final result = traverse.run();
+        expect(result, isA<None>());
+        expect(sideEffect, list.length);
+      });
+    });
+
+    group('traverseTaskOptionWithIndex', () {
+      test('Some', () async {
+        final list = [1, 2, 3, 4, 5, 6];
+        var sideEffect = 0;
+        final traverse = list.traverseTaskOptionWithIndex<String>(
+          (a, i) => TaskOption(
+            () async {
+              await AsyncUtils.waitFuture();
+              sideEffect += 1;
+              return some("$a$i");
+            },
+          ),
+        );
+        expect(sideEffect, 0);
+        final result = await traverse.run();
+        result.matchTestSome((t) {
+          expect(t, ['10', '21', '32', '43', '54', '65']);
+        });
+        expect(sideEffect, list.length);
+      });
+
+      test('None', () async {
+        final list = [1, 2, 3, 4, 5, 6];
+        var sideEffect = 0;
+        final traverse = list.traverseTaskOptionWithIndex<String>(
+          (a, i) => TaskOption(
+            () async {
+              await AsyncUtils.waitFuture();
+              sideEffect += 1;
+              return a % 2 == 0 ? some("$a$i") : none();
+            },
+          ),
+        );
+        expect(sideEffect, 0);
+        final result = await traverse.run();
+        expect(result, isA<None>());
+        expect(sideEffect, list.length);
+      });
+    });
+
     group('traverseTaskOption', () {
       test('Some', () async {
         final list = [1, 2, 3, 4, 5, 6];
@@ -1160,6 +1238,66 @@ void main() {
       final result = list.partitionEithersEither();
       expect(result.first, ['a', 'b']);
       expect(result.second, [1, 2, 3]);
+    });
+  });
+
+  group('FpdartSequenceIterableIOOption', () {
+    group('sequenceIOOption', () {
+      test('Some', () {
+        var sideEffect = 0;
+        final list = [
+          IOOption(() {
+            sideEffect += 1;
+            return some(1);
+          }),
+          IOOption(() {
+            sideEffect += 1;
+            return some(2);
+          }),
+          IOOption(() {
+            sideEffect += 1;
+            return some(3);
+          }),
+          IOOption(() {
+            sideEffect += 1;
+            return some(4);
+          }),
+        ];
+        final traverse = list.sequenceIOOption();
+        expect(sideEffect, 0);
+        final result = traverse.run();
+        result.matchTestSome((t) {
+          expect(t, [1, 2, 3, 4]);
+        });
+        expect(sideEffect, list.length);
+      });
+
+      test('None', () {
+        var sideEffect = 0;
+        final list = [
+          IOOption(() {
+            sideEffect += 1;
+            return some(1);
+          }),
+          IOOption(() {
+            sideEffect += 1;
+            return none<int>();
+          }),
+          IOOption(() {
+            sideEffect += 1;
+            return some(3);
+          }),
+          IOOption(() {
+            sideEffect += 1;
+            return some(4);
+          }),
+        ];
+        final traverse = list.sequenceIOOption();
+        expect(sideEffect, 0);
+        final result = traverse.run();
+        expect(result, isA<None>());
+        expect(sideEffect, list.length);
+      });
     });
   });
 

--- a/test/src/nullable_extension_test.dart
+++ b/test/src/nullable_extension_test.dart
@@ -38,6 +38,24 @@ void main() {
       });
     });
 
+    group("toIOOption", () {
+      test('Right', () {
+        final value = 10;
+        final io = value.toIOOption();
+        final result = io.run();
+        result.matchTestSome((t) {
+          expect(t, value);
+        });
+      });
+
+      test('Left', () {
+        int? value = null;
+        final io = value.toIOOption();
+        final result = io.run();
+        expect(result, isA<None>());
+      });
+    });
+
     group("toTaskOption", () {
       test('Right', () async {
         final value = 10;

--- a/test/src/option_test.dart
+++ b/test/src/option_test.dart
@@ -628,6 +628,27 @@ void main() {
       });
     });
 
+    group('safeCast', () {
+      test('dynamic', () {
+        final castInt = Option.safeCast(10);
+        final castString = Option.safeCast('abc');
+        expect(castInt, isA<Some<dynamic>>());
+        expect(castString, isA<Some<dynamic>>());
+      });
+
+      test('Some', () {
+        final cast = Option<int>.safeCast(10);
+        cast.matchTestSome((r) {
+          expect(r, 10);
+        });
+      });
+
+      test('None', () {
+        final cast = Option<int>.safeCast('abc');
+        expect(cast, isA<None>());
+      });
+    });
+
     group('toTaskOption', () {
       test('Some', () async {
         final m = Option.of(10);
@@ -640,6 +661,22 @@ void main() {
         final m = Option<int>.none();
         final taskOption = m.toTaskOption();
         final result = await taskOption.run();
+        expect(result, m);
+      });
+    });
+
+    group('toIOOption', () {
+      test('Some', () async {
+        final m = Option.of(10);
+        final ioOption = m.toIOOption();
+        final result = ioOption.run();
+        expect(result, m);
+      });
+
+      test('None', () {
+        final m = Option<int>.none();
+        final ioOption = m.toIOOption();
+        final result = ioOption.run();
         expect(result, m);
       });
     });
@@ -689,27 +726,6 @@ void main() {
       expect(map1, map2);
       expect(map1, map3);
       expect(map1 == map4, false);
-    });
-  });
-
-  group('safeCast', () {
-    test('dynamic', () {
-      final castInt = Option.safeCast(10);
-      final castString = Option.safeCast('abc');
-      expect(castInt, isA<Some<dynamic>>());
-      expect(castString, isA<Some<dynamic>>());
-    });
-
-    test('Some', () {
-      final cast = Option<int>.safeCast(10);
-      cast.matchTestSome((r) {
-        expect(r, 10);
-      });
-    });
-
-    test('None', () {
-      final cast = Option<int>.safeCast('abc');
-      expect(cast, isA<None>());
     });
   });
 

--- a/test/src/task_option_test.dart
+++ b/test/src/task_option_test.dart
@@ -347,6 +347,26 @@ void main() {
       expect(stopwatch.elapsedMilliseconds >= 2000, true);
     });
 
+    group('toTaskEither', () {
+      test('Some', () async {
+        final task = TaskOption(() async => Option.of(10));
+        final convert = task.toTaskEither(() => 'None');
+        final r = await convert.run();
+        r.matchTestRight((r) {
+          expect(r, 10);
+        });
+      });
+
+      test('None', () async {
+        final task = TaskOption(() async => const Option.none());
+        final convert = task.toTaskEither(() => 'None');
+        final r = await convert.run();
+        r.matchTestLeft((l) {
+          expect(l, 'None');
+        });
+      });
+    });
+
     group('sequenceList', () {
       test('Some', () async {
         var sideEffect = 0;

--- a/test/src/task_test.dart
+++ b/test/src/task_test.dart
@@ -127,6 +127,24 @@ void main() {
       });
     });
 
+    test('toTaskOption', () async {
+      final io = Task.of(10);
+      final convert = io.toTaskOption();
+      final r = await convert.run();
+      r.matchTestSome((r) {
+        expect(r, 10);
+      });
+    });
+
+    test('toTaskEither', () async {
+      final io = Task.of(10);
+      final convert = io.toTaskEither();
+      final r = await convert.run();
+      r.matchTestRight((r) {
+        expect(r, 10);
+      });
+    });
+
     test('sequenceList', () async {
       var sideEffect = 0;
       final list = [


### PR DESCRIPTION
Added `IOOption` type (`IO` + `Option` utility).

Added also conversion function between types (`IO`, `Task`, `IOOption`, `IOEither`, `TaskOption`, `TaskEither`).