### PR TITLE
Class modifiers (Dart 3)

### DIFF
--- a/packages/fpdart/CHANGELOG.md
+++ b/packages/fpdart/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.0.0 - Soon
+- `Either` as `sealed` class
+  - You can now use exhaustive pattern matching (`Left` or `Right`)
+- `Option` as `sealed` class
+  - You can now use exhaustive pattern matching (`None` or `Some`)
+- `Unit` type as `final` class (no `extends` nor `implements`)
+
 ## v0.6.0 - 6 May 2023
 - Do notation [#97](https://github.com/SandroMaglione/fpdart/pull/97) (Special thanks to [@tim-smart](https://github.com/tim-smart) 🎉)
   - All the main types now have a **`Do()` constructor** used to initialize a Do notation chain

--- a/packages/fpdart/CHANGELOG.md
+++ b/packages/fpdart/CHANGELOG.md
@@ -3,7 +3,19 @@
   - You can now use exhaustive pattern matching (`Left` or `Right`)
 - `Option` as `sealed` class
   - You can now use exhaustive pattern matching (`None` or `Some`)
-- `Unit` type as `final` class (no `extends` nor `implements`)
+- Types marked as `final` (no `extends` nor `implements`)
+  - `Unit`
+  - `Predicate`
+  - `Reader`
+  - `State`
+  - `StateAsync`
+  - `IO` 
+  - `IORef` 
+  - `IOOption` 
+  - `IOEither` 
+  - `Task` 
+  - `TaskOption` 
+  - `TaskEither` 
 
 ## v0.6.0 - 6 May 2023
 - Do notation [#97](https://github.com/SandroMaglione/fpdart/pull/97) (Special thanks to [@tim-smart](https://github.com/tim-smart) 🎉)

--- a/packages/fpdart/lib/src/either.dart
+++ b/packages/fpdart/lib/src/either.dart
@@ -15,7 +15,7 @@ Either<L, R> right<L, R>(R r) => Right<L, R>(r);
 /// Shortcut for `Either.left(l)`.
 Either<L, R> left<L, R>(L l) => Left<L, R>(l);
 
-class _EitherThrow<L> {
+final class _EitherThrow<L> {
   final L value;
   const _EitherThrow(this.value);
 }
@@ -29,7 +29,7 @@ DoAdapterEither<L> _doAdapter<L>() =>
 typedef DoFunctionEither<L, R> = R Function(DoAdapterEither<L> $);
 
 /// Tag the [HKT2] interface for the actual [Either].
-abstract class _EitherHKT {}
+abstract final class _EitherHKT {}
 
 /// Represents a value of one of two possible types, [Left] or [Right].
 ///
@@ -37,7 +37,7 @@ abstract class _EitherHKT {}
 /// values when a computation may fail (such as `-1`, `null`, etc.), we return an instance
 /// of [Right] containing the correct result when a computation is successful, otherwise we return
 /// an instance of [Left] containing information about the kind of error that occurred.
-abstract class Either<L, R> extends HKT2<_EitherHKT, L, R>
+sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
     with
         Functor2<_EitherHKT, L, R>,
         Applicative2<_EitherHKT, L, R>,

--- a/packages/fpdart/lib/src/io.dart
+++ b/packages/fpdart/lib/src/io.dart
@@ -17,13 +17,13 @@ A _doAdapter<A>(IO<A> io) => io.run();
 typedef DoFunctionIO<A> = A Function(DoAdapterIO $);
 
 /// Tag the [HKT] interface for the actual [Option].
-abstract class _IOHKT {}
+abstract final class _IOHKT {}
 
 /// `IO<A>` represents a **non-deterministic synchronous** computation that
 /// can **cause side effects**, yields a value of type `A` and **never fails**.
 ///
 /// If you want to represent a synchronous computation that may fail, see [IOEither].
-class IO<A> extends HKT<_IOHKT, A>
+final class IO<A> extends HKT<_IOHKT, A>
     with Functor<_IOHKT, A>, Applicative<_IOHKT, A>, Monad<_IOHKT, A> {
   final A Function() _run;
 

--- a/packages/fpdart/lib/src/io_either.dart
+++ b/packages/fpdart/lib/src/io_either.dart
@@ -9,7 +9,7 @@ import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
-class _IOEitherThrow<L> {
+final class _IOEitherThrow<L> {
   final L value;
   const _IOEitherThrow(this.value);
 }
@@ -21,14 +21,14 @@ DoAdapterIOEither<L> _doAdapter<L>() =>
 typedef DoFunctionIOEither<L, A> = A Function(DoAdapterIOEither<L> $);
 
 /// Tag the [HKT2] interface for the actual [IOEither].
-abstract class _IOEitherHKT {}
+abstract final class _IOEitherHKT {}
 
 /// `IOEither<L, R>` represents a **non-deterministic synchronous** computation that
 /// can **cause side effects**, yields a value of type `R` or **can fail** by returning
 /// a value of type `L`.
 ///
 /// If you want to represent a synchronous computation that may never fail, see [IO].
-class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
+final class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
     with
         Functor2<_IOEitherHKT, L, R>,
         Applicative2<_IOEitherHKT, L, R>,

--- a/packages/fpdart/lib/src/io_option.dart
+++ b/packages/fpdart/lib/src/io_option.dart
@@ -11,7 +11,7 @@ import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
-class _IOOptionThrow {
+final class _IOOptionThrow {
   const _IOOptionThrow();
 }
 
@@ -23,7 +23,7 @@ A _doAdapter<A>(IOOption<A> iOOption) => iOOption.run().getOrElse(
 typedef DoFunctionIOOption<A> = A Function(DoAdapterIOOption $);
 
 /// Tag the [HKT] interface for the actual [IOOption].
-abstract class _IOOptionHKT {}
+abstract final class _IOOptionHKT {}
 
 /// `IOOption<R>` represents an **synchronous** computation that
 /// may fails yielding a [None] or returns a `Some(R)` when successful.
@@ -32,7 +32,7 @@ abstract class _IOOptionHKT {}
 ///
 /// If you want to represent an synchronous computation that returns an object when it fails,
 /// see [IOEither].
-class IOOption<R> extends HKT<_IOOptionHKT, R>
+final class IOOption<R> extends HKT<_IOOptionHKT, R>
     with
         Functor<_IOOptionHKT, R>,
         Applicative<_IOOptionHKT, R>,

--- a/packages/fpdart/lib/src/io_ref.dart
+++ b/packages/fpdart/lib/src/io_ref.dart
@@ -13,7 +13,7 @@ import 'unit.dart';
 /// In most cases, the [State] monad should be used, and [IORef] must be
 /// viewed as a last resort, as it holds a mutable field inside itself that can
 /// be modified inside of the [IO] monad.
-class IORef<T> {
+final class IORef<T> {
   T _value;
 
   IORef._(this._value);

--- a/packages/fpdart/lib/src/option.dart
+++ b/packages/fpdart/lib/src/option.dart
@@ -36,7 +36,7 @@ Option<T> optionOf<T>(T? t) => Option.fromNullable(t);
 Option<T> option<T>(T value, bool Function(T) predicate) =>
     Option.fromPredicate(value, predicate);
 
-class _OptionThrow {
+final class _OptionThrow {
   const _OptionThrow();
 }
 
@@ -47,7 +47,7 @@ A _doAdapter<A>(Option<A> option) =>
 typedef DoFunctionOption<A> = A Function(DoAdapterOption $);
 
 /// Tag the [HKT] interface for the actual [Option].
-abstract class _OptionHKT {}
+abstract final class _OptionHKT {}
 
 // `Option<T> implements Functor<OptionHKT, T>` expresses correctly the
 // return type of the `map` function as `HKT<OptionHKT, B>`.
@@ -72,7 +72,7 @@ abstract class _OptionHKT {}
 ///   printString,
 /// );
 /// ```
-abstract class Option<T> extends HKT<_OptionHKT, T>
+sealed class Option<T> extends HKT<_OptionHKT, T>
     with
         Functor<_OptionHKT, T>,
         Applicative<_OptionHKT, T>,

--- a/packages/fpdart/lib/src/predicate.dart
+++ b/packages/fpdart/lib/src/predicate.dart
@@ -1,5 +1,5 @@
 /// Compose functions that given a generic value [T] return a `bool`.
-class Predicate<T> {
+final class Predicate<T> {
   final bool Function(T t) _predicate;
 
   /// Build a [Predicate] given a function returning a `bool`.

--- a/packages/fpdart/lib/src/reader.dart
+++ b/packages/fpdart/lib/src/reader.dart
@@ -5,12 +5,12 @@ import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
 /// Tag the [HKT2] interface for the actual [Reader].
-abstract class ReaderHKT {}
+abstract final class ReaderHKT {}
 
 /// `Reader<R, A>` allows to read values `A` from a dependency/context `R`
 /// without explicitly passing the dependency between multiple nested
 /// function calls.
-class Reader<R, A> extends HKT2<ReaderHKT, R, A>
+final class Reader<R, A> extends HKT2<ReaderHKT, R, A>
     with
         Functor2<ReaderHKT, R, A>,
         Applicative2<ReaderHKT, R, A>,

--- a/packages/fpdart/lib/src/state.dart
+++ b/packages/fpdart/lib/src/state.dart
@@ -5,14 +5,14 @@ import 'typeclass/typeclass.export.dart';
 import 'unit.dart';
 
 /// Tag the [HKT2] interface for the actual [State].
-abstract class _StateHKT {}
+abstract final class _StateHKT {}
 
 /// `State<S, A>` is used to store, update, and extract state in a functional way.
 ///
 /// `S` is a State (e.g. the current _State_ of your Bank Account).
 /// `A` is value that you _extract out of the [State]_
 /// (Account Balance fetched from the current state of your Bank Account `S`).
-class State<S, A> extends HKT2<_StateHKT, S, A>
+final class State<S, A> extends HKT2<_StateHKT, S, A>
     with
         Functor2<_StateHKT, S, A>,
         Applicative2<_StateHKT, S, A>,

--- a/packages/fpdart/lib/src/state_async.dart
+++ b/packages/fpdart/lib/src/state_async.dart
@@ -5,7 +5,7 @@ import 'typeclass/typeclass.export.dart';
 import 'unit.dart';
 
 /// Tag the [HKT2] interface for the actual [StateAsync].
-abstract class _StateAsyncHKT {}
+abstract final class _StateAsyncHKT {}
 
 /// `StateAsync<S, A>` is used to store, update, and extract async state in a functional way.
 ///
@@ -14,7 +14,7 @@ abstract class _StateAsyncHKT {}
 /// (Account Balance fetched from the current state of your Bank Account `S`).
 ///
 /// Used when fetching and updating the state is **asynchronous**. Use [State] otherwise.
-class StateAsync<S, A> extends HKT2<_StateAsyncHKT, S, A>
+final class StateAsync<S, A> extends HKT2<_StateAsyncHKT, S, A>
     with
         Functor2<_StateAsyncHKT, S, A>,
         Applicative2<_StateAsyncHKT, S, A>,

--- a/packages/fpdart/lib/src/task.dart
+++ b/packages/fpdart/lib/src/task.dart
@@ -15,12 +15,12 @@ Future<A> _doAdapter<A>(Task<A> task) => task.run();
 typedef DoFunctionTask<A> = Future<A> Function(DoAdapterTask $);
 
 /// Tag the [HKT] interface for the actual [Task].
-abstract class _TaskHKT {}
+abstract final class _TaskHKT {}
 
 /// [Task] represents an asynchronous computation that yields a value of type `A` and **never fails**.
 ///
 /// If you want to represent an asynchronous computation that may fail, see [TaskEither].
-class Task<A> extends HKT<_TaskHKT, A>
+final class Task<A> extends HKT<_TaskHKT, A>
     with Functor<_TaskHKT, A>, Applicative<_TaskHKT, A>, Monad<_TaskHKT, A> {
   final Future<A> Function() _run;
 

--- a/packages/fpdart/lib/src/task_either.dart
+++ b/packages/fpdart/lib/src/task_either.dart
@@ -8,7 +8,7 @@ import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
-class _TaskEitherThrow<L> {
+final class _TaskEitherThrow<L> {
   final L value;
   const _TaskEitherThrow(this.value);
 }
@@ -23,13 +23,13 @@ typedef DoFunctionTaskEither<L, A> = Future<A> Function(
     DoAdapterTaskEither<L> $);
 
 /// Tag the [HKT2] interface for the actual [TaskEither].
-abstract class _TaskEitherHKT {}
+abstract final class _TaskEitherHKT {}
 
 /// `TaskEither<L, R>` represents an asynchronous computation that
 /// either yields a value of type `R` or fails yielding an error of type `L`.
 ///
 /// If you want to represent an asynchronous computation that never fails, see [Task].
-class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
+final class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
     with
         Functor2<_TaskEitherHKT, L, R>,
         Applicative2<_TaskEitherHKT, L, R>,

--- a/packages/fpdart/lib/src/task_option.dart
+++ b/packages/fpdart/lib/src/task_option.dart
@@ -9,7 +9,7 @@ import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
-class _TaskOptionThrow {
+final class _TaskOptionThrow {
   const _TaskOptionThrow();
 }
 
@@ -21,7 +21,7 @@ Future<A> _doAdapter<A>(TaskOption<A> taskOption) => taskOption.run().then(
 typedef DoFunctionTaskOption<A> = Future<A> Function(DoAdapterTaskOption $);
 
 /// Tag the [HKT] interface for the actual [TaskOption].
-abstract class _TaskOptionHKT {}
+abstract final class _TaskOptionHKT {}
 
 /// `TaskOption<R>` represents an **asynchronous** computation that
 /// may fails yielding a [None] or returns a `Some(R)` when successful.
@@ -30,7 +30,7 @@ abstract class _TaskOptionHKT {}
 ///
 /// If you want to represent an asynchronous computation that returns an object when it fails,
 /// see [TaskEither].
-class TaskOption<R> extends HKT<_TaskOptionHKT, R>
+final class TaskOption<R> extends HKT<_TaskOptionHKT, R>
     with
         Functor<_TaskOptionHKT, R>,
         Applicative<_TaskOptionHKT, R>,

--- a/packages/fpdart/lib/src/unit.dart
+++ b/packages/fpdart/lib/src/unit.dart
@@ -4,7 +4,7 @@
 /// to understand why it is better to not use `void` and use [Unit] instead.
 ///
 /// There is only one value of type [Unit].
-class Unit {
+final class Unit {
   static const Unit _unit = Unit._instance();
   const Unit._instance();
 

--- a/packages/fpdart/pubspec.yaml
+++ b/packages/fpdart/pubspec.yaml
@@ -10,7 +10,7 @@ documentation: https://www.sandromaglione.com/course/fpdart-functional-programmi
 issue_tracker: https://github.com/SandroMaglione/fpdart/issues
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
   lints: ^2.0.1


### PR DESCRIPTION
Added [class modifiers](https://dart.dev/language/class-modifiers) to `fpdart` classes:
- `Either` and `Option` as sealed (exhaustive pattern matching on `Left`/`Right` and `None`/`Some`)
- Types marked as `final` (no more possible to use `extends` and `implements` on `fpdart` types)