### PR TITLE
Improve performance of some iterable based functions.

### DIFF
--- a/packages/fpdart/CHANGELOG.md
+++ b/packages/fpdart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.1.0-dev
+
+- Added `lookupEq` and `dropRight` on `Iterable`.
+- Added `lookupKeyEq` on `Map`.
+- Some optimization.
+
 ## v1.0.0-beta.1 - 27 May 2023
 - Minimum environment dart sdk to `3.0.0` ⚠️ (Dart 3️⃣)
 ```yaml

--- a/packages/fpdart/lib/src/extension/predicate_extension.dart
+++ b/packages/fpdart/lib/src/extension/predicate_extension.dart
@@ -37,11 +37,8 @@ extension FpdartOnPredicate1<P> on bool Function(P) {
       (p) => this(p) || predicate(p);
 
   /// Compose **xor** this function with `predicate`.
-  bool Function(P) xor(bool Function(P) predicate) => (p) {
-        final thisPredicate = this(p);
-        final otherPredicate = predicate(p);
-        return thisPredicate ? !otherPredicate : otherPredicate;
-      };
+  bool Function(P) xor(bool Function(P) predicate) =>
+      (p) => this(p) ^ predicate(p);
 
   /// Apply `map` to the value of the parameter `P` and return a new `bool Function(A)`.
   ///

--- a/packages/fpdart/test/src/extension/iterable_extension_test.dart
+++ b/packages/fpdart/test/src/extension/iterable_extension_test.dart
@@ -294,6 +294,29 @@ void main() {
       expect(eq(ap, [3, 4, 5]), true);
     });
 
+    group('dropRight', () {
+      test('none', () {
+        expect([].dropRight(0), isEmpty);
+        expect([].dropRight(1), isEmpty);
+        expect([].dropRight(2), isEmpty);
+        expect([1].dropRight(1), isEmpty);
+        expect([1, 2].dropRight(2), isEmpty);
+        expect([1, 2].dropRight(3), isEmpty);
+      });
+
+      test('some', () {
+        expect([1, 2, 3, 4].dropRight(0), [1, 2, 3, 4]);
+        expect([1, 2, 3, 4].dropRight(1), [1, 2, 3]);
+        expect([1, 2, 3, 4].dropRight(2), [1, 2]);
+        expect([1, 2, 3, 4].dropRight(3), [1]);
+        // Is lazy.
+        var list = [1, 2, 3];
+        var dropList = list.dropRight(5);
+        list.addAll([4, 5, 6]);
+        expect(dropList, [1]);
+      });
+    });
+
     test('foldLeft', () {
       final list1 = [1, 2, 3];
       final ap = list1.foldLeft<int>(0, (b, t) => b - t);
@@ -408,6 +431,29 @@ void main() {
         expect(ap2, true);
         expect(ap3, true);
         expect(ap4, true);
+      });
+    });
+
+    group('lookupEq', () {
+      test('none', () {
+        expect([].lookupEq(Eq.eqInt, 5), isA<None>());
+      });
+
+      test('none found', () {
+        expect([1, 2, 3, 4].lookupEq(Eq.eqInt, 5), isA<None>());
+      });
+
+      test('found', () {
+        var find3 = [1, 2, 3, 4].lookupEq(Eq.eqInt, 3);
+        expect(find3, isA<Some>());
+        expect(find3.getOrElse(() => throw "not"), 3);
+      });
+
+      test('found first', () {
+        var findMod3 =
+            [1, 6, 4, 3, 2].lookupEq(Eq.by((int n) => n % 3, Eq.eqInt), 0);
+        expect(findMod3, isA<Some>());
+        expect(findMod3.getOrElse(() => throw "not"), 6);
       });
     });
   });

--- a/packages/fpdart/test/src/extension/map_extension_test.dart
+++ b/packages/fpdart/test/src/extension/map_extension_test.dart
@@ -146,6 +146,22 @@ void main() {
       });
     });
 
+    group('lookupKeyEq', () {
+      test('Some', () {
+        testImmutableMap({'a': 1, 'b': 2, 'c': 3, 'd': 4}, (value) {
+          value.lookupKeyEq(Eq.eqString, 'b').matchTestSome((t) {
+            expect(t, 'b');
+          });
+        });
+      });
+
+      test('None', () {
+        testImmutableMap({'a': 1, 'b': 2, 'c': 3, 'd': 4}, (value) {
+          expect(value.lookupKeyEq(Eq.eqString, 'e'), isA<None>());
+        });
+      });
+    });
+
     group('extract', () {
       test('valid', () {
         testImmutableMap({'a': 1, 'b': 2, 'c': 3, 'd': 4}, (value) {


### PR DESCRIPTION
Avoid repeatedly iterating the same iterable.
Includes iteration of maps (mainly entries), and uses map literals more. Adds a few functions that the code uses.

(The functional approach of doing something to `first` and then recursing on `.skip(1)` is not efficient for Dart iterables. Iterating the `.skip(1)` iterable will still take time to move past the skipped elements, so the complexity becomes, at least, quadratic.)