### PR TITLE
Add fold method to TaskEither

### DIFF
--- a/packages/fpdart/lib/src/task_either.dart
+++ b/packages/fpdart/lib/src/task_either.dart
@@ -164,8 +164,17 @@ final class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
   ///
   /// Execute `onLeft` when running this [TaskEither] returns a [Left].
   /// Otherwise execute `onRight`.
+  /// Same as `fold`.
   Task<A> match<A>(A Function(L l) onLeft, A Function(R r) onRight) =>
       Task(() async => (await run()).match(onLeft, onRight));
+
+  /// Pattern matching to convert a [TaskEither] to a [Task].
+  ///
+  /// Execute `onLeft` when running this [TaskEither] returns a [Left].
+  /// Otherwise execute `onRight`.
+  /// Same as `match`.
+  Task<A> fold<A>(A Function(L l) onLeft, A Function(R r) onRight) =>
+    Task(() async => (await run()).fold(onLeft, onRight));
 
   /// Creates a [TaskEither] that will complete after a time delay specified by a [Duration].
   TaskEither<L, R> delay(Duration duration) =>

--- a/packages/fpdart/test/src/task_either_test.dart
+++ b/packages/fpdart/test/src/task_either_test.dart
@@ -507,6 +507,22 @@ void main() {
       });
     });
 
+    group('fold', () {
+      test('Right', () async {
+        final task = TaskEither<String, int>(() async => Either.of(10));
+        final ex = task.fold((l) => l.length, (r) => r + 10);
+        final r = await ex.run();
+        expect(r, 20);
+      });
+
+      test('Left', () async {
+        final task = TaskEither<String, int>(() async => Either.left('none'));
+        final ex = task.fold((l) => l.length, (r) => r + 10);
+        final r = await ex.run();
+        expect(r, 4);
+      });
+    });
+
     group('getOrElse', () {
       test('Right', () async {
         final task = TaskEither<String, int>(() async => Either.of(10));


### PR DESCRIPTION
**PR Description**

resolve: #162

- Added fold method to TaskEither for consistency with `Either.fold`.
- fold behaves the same as match, allowing Left/Right case handling.
- Included unit tests to verify both Left and Right cases.