### PR TITLE
Lint cleanup + .fromComposition constructors

### DIFF
--- a/packages/fpdart/example/logger/logger.dart
+++ b/packages/fpdart/example/logger/logger.dart
@@ -68,7 +68,7 @@ class Logger {
         var outputEvent = OutputEvent(level, output);
         try {
           _output.output(outputEvent);
-        } catch (e, s) {
+        } on Exception catch (e, s) {
           print(e);
           print(s);
         }

--- a/packages/fpdart/example/logger/main.dart
+++ b/packages/fpdart/example/logger/main.dart
@@ -39,7 +39,7 @@ class Logger {
         var outputEvent = OutputEvent(level, output);
         try {
           _output.output(outputEvent);
-        } catch (e, s) {
+        } on Exception catch (e, s) {
           print(e);
           print(s);
         }

--- a/packages/fpdart/example/src/either/chain_either.dart
+++ b/packages/fpdart/example/src/either/chain_either.dart
@@ -50,7 +50,7 @@ Future<void> placeOrder() async {
     await ordersRepository.addOrder(uid, order);
     // third await call
     await cartRepository.setCart(uid, const Cart());
-  } catch (e) {
+  } on Exception catch (e) {
     // TODO: Handle exceptions from any of the methods above
   }
 

--- a/packages/fpdart/example/src/list/overview.dart
+++ b/packages/fpdart/example/src/list/overview.dart
@@ -8,8 +8,8 @@ void main() {
   [1, 2, 3, 4].head;
 
   /// Dart: Throws a [StateError] ⚠️
-  [].first;
+  <int>[].first;
 
   /// fpdart: `None()`
-  [].head;
+  <int>[].head;
 }

--- a/packages/fpdart/example/src/task/task_and_future.dart
+++ b/packages/fpdart/example/src/task/task_and_future.dart
@@ -20,17 +20,17 @@ Future<bool> withFuture() async {
 
   try {
     usernameOrName = await getUsername();
-  } catch (e) {
+  } on Exception catch (e) {
     try {
       usernameOrName = decodeName(await getEncodedName());
-    } catch (e) {
+    } on Exception catch (e) {
       throw Exception("Missing both username and name");
     }
   }
 
   try {
     email = await getEmail();
-  } catch (e) {
+  } on Exception catch (e) {
     throw Exception("Missing email");
   }
 
@@ -38,7 +38,7 @@ Future<bool> withFuture() async {
     final usernameOrNamePrefix = addNamePrefix(usernameOrName);
     final emailPrefix = addEmailPrefix(email);
     return await sendInformation(usernameOrNamePrefix, emailPrefix);
-  } catch (e) {
+  } on Exception catch (e) {
     throw Exception("Error when sending information");
   }
 }

--- a/packages/fpdart/example/src/task_either/finally.dart
+++ b/packages/fpdart/example/src/task_either/finally.dart
@@ -9,7 +9,7 @@ Future<void> imperative() async {
   try {
     final response = await apiRequestMock();
     print(response);
-  } catch (e) {
+  } on Exception catch (e) {
     print("Error: $e");
   } finally {
     print("Complete!");

--- a/packages/fpdart/example/src/task_either/overview.dart
+++ b/packages/fpdart/example/src/task_either/overview.dart
@@ -4,7 +4,7 @@ import 'package:fpdart/fpdart.dart';
 Future<int> imperative(String str) async {
   try {
     return int.parse(str);
-  } catch (e) {
+  } on Exception catch (e) {
     return -1; // What does -1 means? 🤨
   }
 }

--- a/packages/fpdart/lib/src/date.dart
+++ b/packages/fpdart/lib/src/date.dart
@@ -3,7 +3,7 @@ import 'io.dart';
 /// Constructs a [DateTime] instance with current date and time in the local time zone.
 ///
 /// [IO] wrapper around dart `DateTime.now()`.
-IO<DateTime> get dateNow => IO(() => DateTime.now());
+IO<DateTime> get dateNow => const IO(DateTime.now);
 
 /// The number of milliseconds since the "Unix epoch" 1970-01-01T00:00:00Z (UTC).
 ///

--- a/packages/fpdart/lib/src/either.dart
+++ b/packages/fpdart/lib/src/either.dart
@@ -79,7 +79,8 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// Return the result of `f` called with `b` and the value of [Right].
   /// If this [Either] is [Left], return `b`.
   @override
-  C foldRightWithIndex<C>(C c, C Function(int i, C acc, R b) f) => foldRight<(C, int)>(
+  C foldRightWithIndex<C>(C c, C Function(int i, C acc, R b) f) =>
+      foldRight<(C, int)>(
         (c, length() - 1),
         (t, b) => (f(t.$2, t.$1, b), t.$2 - 1),
       ).$1;
@@ -87,7 +88,8 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// Return the result of `f` called with `b` and the value of [Right].
   /// If this [Either] is [Left], return `b`.
   @override
-  C foldLeftWithIndex<C>(C c, C Function(int i, C acc, R b) f) => foldLeft<(C, int)>(
+  C foldLeftWithIndex<C>(C c, C Function(int i, C acc, R b) f) =>
+      foldLeft<(C, int)>(
         (c, 0),
         (t, b) => (f(t.$2, t.$1, b), t.$2 + 1),
       ).$1;
@@ -137,7 +139,8 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// If this [Either] is a [Right], then return the result of calling `then`.
   /// Otherwise return [Left].
   @override
-  Either<L, R2> andThen<R2>(covariant Either<L, R2> Function() then) => flatMap((_) => then());
+  Either<L, R2> andThen<R2>(covariant Either<L, R2> Function() then) =>
+      flatMap((_) => then());
 
   /// Return the current [Either] if it is a [Right], otherwise return the result of `orElse`.
   ///
@@ -155,8 +158,8 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// value of type `C` of a second [Either], and the value of type `D`
   /// of a third [Either].
   @override
-  Either<L, E> map3<C, D, E>(
-          covariant Either<L, C> m1, covariant Either<L, D> m2, E Function(R b, C c, D d) f) =>
+  Either<L, E> map3<C, D, E>(covariant Either<L, C> m1,
+          covariant Either<L, D> m2, E Function(R b, C c, D d) f) =>
       flatMap((b) => m1.flatMap((c) => m2.map((d) => f(b, c, d))));
 
   /// Change the value of [Either] from type `R` to type `Z` based on the
@@ -273,7 +276,8 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// Execute `onLeft` when value is [Left], otherwise execute `onRight`.
   ///
   /// Same as `match`.
-  C fold<C>(C Function(L l) onLeft, C Function(R r) onRight) => match<C>(onLeft, onRight);
+  C fold<C>(C Function(L l) onLeft, C Function(R r) onRight) =>
+      match<C>(onLeft, onRight);
 
   /// Return `true` when value of `r` is equal to the value inside this [Either].
   /// If this [Either] is [Left], then return `false`.
@@ -411,7 +415,8 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
 
   /// If calling `predicate` with `r` returns `true`, then return `Right(r)`.
   /// Otherwise return [Left] containing the result of `onFalse`.
-  factory Either.fromPredicate(R r, bool Function(R r) predicate, L Function(R r) onFalse) =>
+  factory Either.fromPredicate(
+          R r, bool Function(R r) predicate, L Function(R r) onFalse) =>
       predicate(r) ? Either.of(r) : Either.left(onFalse(r));
 
   /// If `r` is `null`, then return the result of `onNull` in [Left].
@@ -421,7 +426,8 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
 
   /// Try to execute `run`. If no error occurs, then return [Right].
   /// Otherwise return [Left] containing the result of `onError`.
-  factory Either.tryCatch(R Function() run, L Function(Object o, StackTrace s) onError) {
+  factory Either.tryCatch(
+      R Function() run, L Function(Object o, StackTrace s) onError) {
     try {
       return Either.of(run());
     } on Exception catch (e, s) {
@@ -477,10 +483,11 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   ///
   /// Return `true` when the two [Either] are equal or when both are [Left] or
   /// [Right] and comparing using `eqL` or `eqR` returns `true`.
-  static Eq<Either<L, R>> getEq<L, R>(Eq<L> eqL, Eq<R> eqR) => Eq.instance((e1, e2) =>
-      e1 == e2 ||
-      (e1.match((l1) => e2.match((l2) => eqL.eqv(l1, l2), (_) => false),
-          (r1) => e2.match((_) => false, (r2) => eqR.eqv(r1, r2)))));
+  static Eq<Either<L, R>> getEq<L, R>(Eq<L> eqL, Eq<R> eqR) =>
+      Eq.instance((e1, e2) =>
+          e1 == e2 ||
+          (e1.match((l1) => e2.match((l2) => eqL.eqv(l1, l2), (_) => false),
+              (r1) => e2.match((_) => false, (r2) => eqR.eqv(r1, r2)))));
 
   /// Build a `Semigroup<Either>` from a [Semigroup].
   ///
@@ -490,7 +497,9 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// When both are [Left], return the first [Either].
   static Semigroup<Either<L, R>> getSemigroup<L, R>(Semigroup<R> semigroup) =>
       Semigroup.instance((e1, e2) => e2.match(
-          (_) => e1, (r2) => e1.match((_) => e2, (r1) => Either.of(semigroup.combine(r1, r2)))));
+          (_) => e1,
+          (r2) => e1.match(
+              (_) => e2, (r1) => Either.of(semigroup.combine(r1, r2)))));
 }
 
 class Right<L, R> extends Either<L, R> {
@@ -505,8 +514,8 @@ class Right<L, R> extends Either<L, R> {
       flatMap((b) => m1.map((c) => f(b, c)));
 
   @override
-  Either<L, E> map3<C, D, E>(
-          covariant Either<L, C> m1, covariant Either<L, D> m2, E Function(R b, C c, D d) f) =>
+  Either<L, E> map3<C, D, E>(covariant Either<L, C> m1,
+          covariant Either<L, D> m2, E Function(R b, C c, D d) f) =>
       flatMap((b) => m1.flatMap((c) => m2.map((d) => f(b, c, d))));
 
   @override
@@ -519,7 +528,8 @@ class Right<L, R> extends Either<L, R> {
   C foldRight<C>(C b, C Function(C acc, R a) f) => f(b, _value);
 
   @override
-  C match<C>(C Function(L l) onLeft, C Function(R r) onRight) => onRight(_value);
+  C match<C>(C Function(L l) onLeft, C Function(R r) onRight) =>
+      onRight(_value);
 
   @override
   Either<L, C> flatMap<C>(covariant Either<L, C> Function(R a) f) => f(_value);
@@ -546,7 +556,8 @@ class Right<L, R> extends Either<L, R> {
   Either<L, Z> extend<Z>(Z Function(Either<L, R> t) f) => Either.of(f(this));
 
   @override
-  Either<L1, R> orElse<L1>(Either<L1, R> Function(L l) onLeft) => Either.of(_value);
+  Either<L1, R> orElse<L1>(Either<L1, R> Function(L l) onLeft) =>
+      Either.of(_value);
 
   @override
   R getOrElse(R Function(L l) orElse) => _value;
@@ -592,8 +603,8 @@ class Left<L, R> extends Either<L, R> {
       flatMap((b) => m1.map((c) => f(b, c)));
 
   @override
-  Either<L, E> map3<C, D, E>(
-          covariant Either<L, C> m1, covariant Either<L, D> m2, E Function(R b, C c, D d) f) =>
+  Either<L, E> map3<C, D, E>(covariant Either<L, C> m1,
+          covariant Either<L, D> m2, E Function(R b, C c, D d) f) =>
       flatMap((b) => m1.flatMap((c) => m2.map((d) => f(b, c, d))));
 
   @override
@@ -609,7 +620,8 @@ class Left<L, R> extends Either<L, R> {
   C match<C>(C Function(L l) onLeft, C Function(R r) onRight) => onLeft(_value);
 
   @override
-  Either<L, C> flatMap<C>(covariant Either<L, C> Function(R a) f) => Left<L, C>(_value);
+  Either<L, C> flatMap<C>(covariant Either<L, C> Function(R a) f) =>
+      Left<L, C>(_value);
 
   @override
   Option<R> toOption() => Option.none();
@@ -633,7 +645,8 @@ class Left<L, R> extends Either<L, R> {
   Either<L, Z> extend<Z>(Z Function(Either<L, R> t) f) => Either.left(_value);
 
   @override
-  Either<L1, R> orElse<L1>(Either<L1, R> Function(L l) onLeft) => onLeft(_value);
+  Either<L1, R> orElse<L1>(Either<L1, R> Function(L l) onLeft) =>
+      onLeft(_value);
 
   @override
   R getOrElse(R Function(L l) orElse) => orElse(_value);

--- a/packages/fpdart/lib/src/either.dart
+++ b/packages/fpdart/lib/src/either.dart
@@ -430,7 +430,7 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
       R Function() run, L Function(Object o, StackTrace s) onError) {
     try {
       return Either.of(run());
-    } on Exception catch (e, s) {
+    } catch (e, s) {
       return Either.left(onError(e, s));
     }
   }

--- a/packages/fpdart/lib/src/either.dart
+++ b/packages/fpdart/lib/src/either.dart
@@ -17,7 +17,7 @@ Either<L, R> right<L, R>(R r) => Right<L, R>(r);
 /// Shortcut for `Either.left(l)`.
 Either<L, R> left<L, R>(L l) => Left<L, R>(l);
 
-final class _EitherThrow<L> {
+final class _EitherThrow<L> implements Exception {
   final L value;
   const _EitherThrow(this.value);
 }

--- a/packages/fpdart/lib/src/either.dart
+++ b/packages/fpdart/lib/src/either.dart
@@ -139,7 +139,7 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// type `R` to a value of type `C`.
   @override
   Either<L, C> ap<C>(covariant Either<L, C Function(R r)> a) =>
-      a.flatMap((f) => map(f));
+      a.flatMap(map);
 
   /// If this [Either] is a [Right], then return the result of calling `then`.
   /// Otherwise return [Left].
@@ -415,7 +415,7 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// - If [Option] is [None], then return [Left] containing the result of `onNone`
   factory Either.fromOption(Option<R> m, L Function() onNone) => m.match(
         () => Either.left(onNone()),
-        (r) => Either.of(r),
+        Either<L, R>.of,
       );
 
   /// If calling `predicate` with `r` returns `true`, then return `Right(r)`.

--- a/packages/fpdart/lib/src/either.dart
+++ b/packages/fpdart/lib/src/either.dart
@@ -33,7 +33,6 @@ typedef DoFunctionEither<L, R> = R Function(DoAdapterEither<L> $);
 abstract final class _EitherHKT {}
 
 @immutable
-
 /// Represents a value of one of two possible types, [Left] or [Right].
 ///
 /// [Either] is commonly used to **handle errors**. Instead of returning placeholder

--- a/packages/fpdart/lib/src/either.dart
+++ b/packages/fpdart/lib/src/either.dart
@@ -24,7 +24,7 @@ final class _EitherThrow<L> {
 
 typedef DoAdapterEither<L> = R Function<R>(Either<L, R>);
 DoAdapterEither<L> _doAdapter<L>() =>
-    <R>(Either<L, R> either) => either.getOrElse(
+    <R>(either) => either.getOrElse(
           (l) => throw _EitherThrow(l),
         );
 
@@ -73,7 +73,7 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// If this [Either] is [Left], return `b`.
   @override
   C foldLeft<C>(C b, C Function(C acc, R b) f) =>
-      foldMap<Endo<C>>(dualEndoMonoid(), (b) => (C c) => f(c, b))(b);
+      foldMap<Endo<C>>(dualEndoMonoid(), (b) => (c) => f(c, b))(b);
 
   /// Use `monoid` to combine the value of [Right] applied to `f`.
   @override
@@ -314,7 +314,7 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
         resultList.add(e._value);
       } else {
         throw Exception(
-          "[fpdart]: Error when mapping Either, it should be either Left or Right.",
+          '[fpdart]: Error when mapping Either, it should be either Left or Right.',
         );
       }
     }
@@ -386,7 +386,7 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
         resultListRights.add(e._value);
       } else {
         throw Exception(
-          "[fpdart]: Error when mapping Either, it should be either Left or Right.",
+          '[fpdart]: Error when mapping Either, it should be either Left or Right.',
         );
       }
     }
@@ -580,7 +580,7 @@ class Right<L, R> extends Either<L, R> {
 
   @override
   TaskEither<L, R2> bindFuture<R2>(Future<Either<L, R2>> Function(R r) f) =>
-      TaskEither(() async => f(_value));
+      TaskEither(() => f(_value));
 
   @override
   TaskEither<L, R> toTaskEither() => TaskEither.of(_value);

--- a/packages/fpdart/lib/src/either.dart
+++ b/packages/fpdart/lib/src/either.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import 'function.dart';
 import 'io_either.dart';
 import 'option.dart';
@@ -31,6 +33,7 @@ typedef DoFunctionEither<L, R> = R Function(DoAdapterEither<L> $);
 /// Tag the [HKT2] interface for the actual [Either].
 abstract final class _EitherHKT {}
 
+@immutable
 /// Represents a value of one of two possible types, [Left] or [Right].
 ///
 /// [Either] is commonly used to **handle errors**. Instead of returning placeholder

--- a/packages/fpdart/lib/src/either.dart
+++ b/packages/fpdart/lib/src/either.dart
@@ -435,7 +435,7 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
       R Function() run, L Function(Object o, StackTrace s) onError) {
     try {
       return Either.of(run());
-    } catch (e, s) {
+    } on Exception catch (e, s) {
       return Either.left(onError(e, s));
     }
   }

--- a/packages/fpdart/lib/src/either.dart
+++ b/packages/fpdart/lib/src/either.dart
@@ -1,7 +1,3 @@
-// Should always be available.
-//ignore: depend_on_referenced_packages
-import 'package:meta/meta.dart';
-
 import 'function.dart';
 import 'io_either.dart';
 import 'option.dart';
@@ -34,7 +30,6 @@ typedef DoFunctionEither<L, R> = R Function(DoAdapterEither<L> $);
 /// Tag the [HKT2] interface for the actual [Either].
 abstract final class _EitherHKT {}
 
-@immutable
 /// Represents a value of one of two possible types, [Left] or [Right].
 ///
 /// [Either] is commonly used to **handle errors**. Instead of returning placeholder

--- a/packages/fpdart/lib/src/either.dart
+++ b/packages/fpdart/lib/src/either.dart
@@ -1,3 +1,5 @@
+// Should always be available.
+//ignore: depend_on_referenced_packages
 import 'package:meta/meta.dart';
 
 import 'function.dart';

--- a/packages/fpdart/lib/src/either.dart
+++ b/packages/fpdart/lib/src/either.dart
@@ -23,10 +23,9 @@ final class _EitherThrow<L> {
 }
 
 typedef DoAdapterEither<L> = R Function<R>(Either<L, R>);
-DoAdapterEither<L> _doAdapter<L>() =>
-    <R>(either) => either.getOrElse(
-          (l) => throw _EitherThrow(l),
-        );
+DoAdapterEither<L> _doAdapter<L>() => <R>(either) => either.getOrElse(
+      (l) => throw _EitherThrow(l),
+    );
 
 typedef DoFunctionEither<L, R> = R Function(DoAdapterEither<L> $);
 
@@ -34,6 +33,7 @@ typedef DoFunctionEither<L, R> = R Function(DoAdapterEither<L> $);
 abstract final class _EitherHKT {}
 
 @immutable
+
 /// Represents a value of one of two possible types, [Left] or [Right].
 ///
 /// [Either] is commonly used to **handle errors**. Instead of returning placeholder
@@ -83,8 +83,7 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// Return the result of `f` called with `b` and the value of [Right].
   /// If this [Either] is [Left], return `b`.
   @override
-  C foldRightWithIndex<C>(C c, C Function(int i, C acc, R b) f) =>
-      foldRight<(C, int)>(
+  C foldRightWithIndex<C>(C c, C Function(int i, C acc, R b) f) => foldRight<(C, int)>(
         (c, length() - 1),
         (t, b) => (f(t.$2, t.$1, b), t.$2 - 1),
       ).$1;
@@ -92,8 +91,7 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// Return the result of `f` called with `b` and the value of [Right].
   /// If this [Either] is [Left], return `b`.
   @override
-  C foldLeftWithIndex<C>(C c, C Function(int i, C acc, R b) f) =>
-      foldLeft<(C, int)>(
+  C foldLeftWithIndex<C>(C c, C Function(int i, C acc, R b) f) => foldLeft<(C, int)>(
         (c, 0),
         (t, b) => (f(t.$2, t.$1, b), t.$2 + 1),
       ).$1;
@@ -138,14 +136,12 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// Apply the function contained inside `a` to change the value on the [Right] from
   /// type `R` to a value of type `C`.
   @override
-  Either<L, C> ap<C>(covariant Either<L, C Function(R r)> a) =>
-      a.flatMap(map);
+  Either<L, C> ap<C>(covariant Either<L, C Function(R r)> a) => a.flatMap(map);
 
   /// If this [Either] is a [Right], then return the result of calling `then`.
   /// Otherwise return [Left].
   @override
-  Either<L, R2> andThen<R2>(covariant Either<L, R2> Function() then) =>
-      flatMap((_) => then());
+  Either<L, R2> andThen<R2>(covariant Either<L, R2> Function() then) => flatMap((_) => then());
 
   /// Return the current [Either] if it is a [Right], otherwise return the result of `orElse`.
   ///
@@ -163,8 +159,8 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// value of type `C` of a second [Either], and the value of type `D`
   /// of a third [Either].
   @override
-  Either<L, E> map3<C, D, E>(covariant Either<L, C> m1,
-          covariant Either<L, D> m2, E Function(R b, C c, D d) f) =>
+  Either<L, E> map3<C, D, E>(
+          covariant Either<L, C> m1, covariant Either<L, D> m2, E Function(R b, C c, D d) f) =>
       flatMap((b) => m1.flatMap((c) => m2.map((d) => f(b, c, d))));
 
   /// Change the value of [Either] from type `R` to type `Z` based on the
@@ -281,8 +277,7 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// Execute `onLeft` when value is [Left], otherwise execute `onRight`.
   ///
   /// Same as `match`.
-  C fold<C>(C Function(L l) onLeft, C Function(R r) onRight) =>
-      match<C>(onLeft, onRight);
+  C fold<C>(C Function(L l) onLeft, C Function(R r) onRight) => match<C>(onLeft, onRight);
 
   /// Return `true` when value of `r` is equal to the value inside this [Either].
   /// If this [Either] is [Left], then return `false`.
@@ -420,8 +415,7 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
 
   /// If calling `predicate` with `r` returns `true`, then return `Right(r)`.
   /// Otherwise return [Left] containing the result of `onFalse`.
-  factory Either.fromPredicate(
-          R r, bool Function(R r) predicate, L Function(R r) onFalse) =>
+  factory Either.fromPredicate(R r, bool Function(R r) predicate, L Function(R r) onFalse) =>
       predicate(r) ? Either.of(r) : Either.left(onFalse(r));
 
   /// If `r` is `null`, then return the result of `onNull` in [Left].
@@ -431,8 +425,7 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
 
   /// Try to execute `run`. If no error occurs, then return [Right].
   /// Otherwise return [Left] containing the result of `onError`.
-  factory Either.tryCatch(
-      R Function() run, L Function(Object o, StackTrace s) onError) {
+  factory Either.tryCatch(R Function() run, L Function(Object o, StackTrace s) onError) {
     try {
       return Either.of(run());
     } on Exception catch (e, s) {
@@ -453,7 +446,11 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// **Note**: Make sure to specify the types of [Either] (`Either<L, R>.safeCast`
   /// instead of `Either.safeCast`), otherwise this will always return [Right]!
   factory Either.safeCast(
+    // `dynamic`s are use for safe-casting
+    //ignore: avoid_annotating_with_dynamic
     dynamic value,
+    // `dynamic`s are use for safe-casting
+    //ignore: avoid_annotating_with_dynamic
     L Function(dynamic value) onError,
   ) =>
       Either.safeCastStrict<L, R, dynamic>(value, onError);
@@ -484,11 +481,10 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   ///
   /// Return `true` when the two [Either] are equal or when both are [Left] or
   /// [Right] and comparing using `eqL` or `eqR` returns `true`.
-  static Eq<Either<L, R>> getEq<L, R>(Eq<L> eqL, Eq<R> eqR) =>
-      Eq.instance((e1, e2) =>
-          e1 == e2 ||
-          (e1.match((l1) => e2.match((l2) => eqL.eqv(l1, l2), (_) => false),
-              (r1) => e2.match((_) => false, (r2) => eqR.eqv(r1, r2)))));
+  static Eq<Either<L, R>> getEq<L, R>(Eq<L> eqL, Eq<R> eqR) => Eq.instance((e1, e2) =>
+      e1 == e2 ||
+      (e1.match((l1) => e2.match((l2) => eqL.eqv(l1, l2), (_) => false),
+          (r1) => e2.match((_) => false, (r2) => eqR.eqv(r1, r2)))));
 
   /// Build a `Semigroup<Either>` from a [Semigroup].
   ///
@@ -498,9 +494,7 @@ sealed class Either<L, R> extends HKT2<_EitherHKT, L, R>
   /// When both are [Left], return the first [Either].
   static Semigroup<Either<L, R>> getSemigroup<L, R>(Semigroup<R> semigroup) =>
       Semigroup.instance((e1, e2) => e2.match(
-          (_) => e1,
-          (r2) => e1.match(
-              (_) => e2, (r1) => Either.of(semigroup.combine(r1, r2)))));
+          (_) => e1, (r2) => e1.match((_) => e2, (r1) => Either.of(semigroup.combine(r1, r2)))));
 }
 
 class Right<L, R> extends Either<L, R> {
@@ -515,8 +509,8 @@ class Right<L, R> extends Either<L, R> {
       flatMap((b) => m1.map((c) => f(b, c)));
 
   @override
-  Either<L, E> map3<C, D, E>(covariant Either<L, C> m1,
-          covariant Either<L, D> m2, E Function(R b, C c, D d) f) =>
+  Either<L, E> map3<C, D, E>(
+          covariant Either<L, C> m1, covariant Either<L, D> m2, E Function(R b, C c, D d) f) =>
       flatMap((b) => m1.flatMap((c) => m2.map((d) => f(b, c, d))));
 
   @override
@@ -529,8 +523,7 @@ class Right<L, R> extends Either<L, R> {
   C foldRight<C>(C b, C Function(C acc, R a) f) => f(b, _value);
 
   @override
-  C match<C>(C Function(L l) onLeft, C Function(R r) onRight) =>
-      onRight(_value);
+  C match<C>(C Function(L l) onLeft, C Function(R r) onRight) => onRight(_value);
 
   @override
   Either<L, C> flatMap<C>(covariant Either<L, C> Function(R a) f) => f(_value);
@@ -557,8 +550,7 @@ class Right<L, R> extends Either<L, R> {
   Either<L, Z> extend<Z>(Z Function(Either<L, R> t) f) => Either.of(f(this));
 
   @override
-  Either<L1, R> orElse<L1>(Either<L1, R> Function(L l) onLeft) =>
-      Either.of(_value);
+  Either<L1, R> orElse<L1>(Either<L1, R> Function(L l) onLeft) => Either.of(_value);
 
   @override
   R getOrElse(R Function(L l) orElse) => _value;
@@ -604,8 +596,8 @@ class Left<L, R> extends Either<L, R> {
       flatMap((b) => m1.map((c) => f(b, c)));
 
   @override
-  Either<L, E> map3<C, D, E>(covariant Either<L, C> m1,
-          covariant Either<L, D> m2, E Function(R b, C c, D d) f) =>
+  Either<L, E> map3<C, D, E>(
+          covariant Either<L, C> m1, covariant Either<L, D> m2, E Function(R b, C c, D d) f) =>
       flatMap((b) => m1.flatMap((c) => m2.map((d) => f(b, c, d))));
 
   @override
@@ -621,8 +613,7 @@ class Left<L, R> extends Either<L, R> {
   C match<C>(C Function(L l) onLeft, C Function(R r) onRight) => onLeft(_value);
 
   @override
-  Either<L, C> flatMap<C>(covariant Either<L, C> Function(R a) f) =>
-      Left<L, C>(_value);
+  Either<L, C> flatMap<C>(covariant Either<L, C> Function(R a) f) => Left<L, C>(_value);
 
   @override
   Option<R> toOption() => Option.none();
@@ -646,8 +637,7 @@ class Left<L, R> extends Either<L, R> {
   Either<L, Z> extend<Z>(Z Function(Either<L, R> t) f) => Either.left(_value);
 
   @override
-  Either<L1, R> orElse<L1>(Either<L1, R> Function(L l) onLeft) =>
-      onLeft(_value);
+  Either<L1, R> orElse<L1>(Either<L1, R> Function(L l) onLeft) => onLeft(_value);
 
   @override
   R getOrElse(R Function(L l) orElse) => orElse(_value);

--- a/packages/fpdart/lib/src/extension/curry_extension.dart
+++ b/packages/fpdart/lib/src/extension/curry_extension.dart
@@ -5,6 +5,7 @@
 /// {@template fpdart_curry_last_extension}
 /// Extract **last** parameter from this function to allow curring.
 /// {@endtemplate}
+library;
 
 extension CurryExtension2<Input1, Input2, Output> on Output Function(
     Input1, Input2) {
@@ -90,7 +91,7 @@ extension UncurryExtension4<Input1, Input2, Input3, Input4, Output>
   ///
   /// Inverse of `curry`.
   Output Function(Input1, Input2, Input3, Input4) get uncurry =>
-      (Input1 input1, Input2 input2, Input3 input3, Input4 input4) =>
+      (input1, input2, input3, input4) =>
           this(input1)(input2)(input3)(input4);
 }
 

--- a/packages/fpdart/lib/src/extension/curry_extension.dart
+++ b/packages/fpdart/lib/src/extension/curry_extension.dart
@@ -5,7 +5,6 @@
 /// {@template fpdart_curry_last_extension}
 /// Extract **last** parameter from this function to allow curring.
 /// {@endtemplate}
-library;
 
 extension CurryExtension2<Input1, Input2, Output> on Output Function(
     Input1, Input2) {

--- a/packages/fpdart/lib/src/extension/curry_extension.dart
+++ b/packages/fpdart/lib/src/extension/curry_extension.dart
@@ -90,8 +90,7 @@ extension UncurryExtension4<Input1, Input2, Input3, Input4, Output>
   ///
   /// Inverse of `curry`.
   Output Function(Input1, Input2, Input3, Input4) get uncurry =>
-      (input1, input2, input3, input4) =>
-          this(input1)(input2)(input3)(input4);
+      (input1, input2, input3, input4) => this(input1)(input2)(input3)(input4);
 }
 
 extension CurryExtension5<Input1, Input2, Input3, Input4, Input5, Output>

--- a/packages/fpdart/lib/src/extension/extension.export.dart
+++ b/packages/fpdart/lib/src/extension/extension.export.dart
@@ -6,3 +6,4 @@ export 'map_extension.dart';
 export 'option_extension.dart';
 export 'predicate_extension.dart';
 export 'string_extension.dart';
+export 'task_extension.dart';

--- a/packages/fpdart/lib/src/extension/iterable_extension.dart
+++ b/packages/fpdart/lib/src/extension/iterable_extension.dart
@@ -423,7 +423,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
       sortWith(getDate, Order.orderDate);
 
   /// Optional version of [elementAt].
-  Option<T> elementAtOption(int index) => Option.fromNullable(elementAt(index));
+  Option<T> elementAtOption(int index) => Option.fromNullable(elementAtOrNull(index));
 
   /// Optional version of [singleWhereOrNull].
   Option<T> singleWhereOption(bool Function(T element) test) => Option.fromNullable(singleWhereOrNull(test));

--- a/packages/fpdart/lib/src/extension/iterable_extension.dart
+++ b/packages/fpdart/lib/src/extension/iterable_extension.dart
@@ -17,7 +17,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
   ///
   /// Same as `firstOption`.
   Option<T> get head {
-    var it = iterator;
+    final it = iterator;
     if (it.moveNext()) return some(it.current);
     return const None();
   }
@@ -66,7 +66,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
   ///
   /// The [count] must be non-negative.
   Iterable<T> dropRight([int count = 1]) {
-    if (count < 0) throw RangeError.range(count, 0, null, "count");
+    if (count < 0) throw RangeError.range(count, 0, null, 'count');
     if (count == 0) return this;
     if (count == 1) return _dropLastHelper(this);
     return _dropRightHelper(this, count);
@@ -74,11 +74,11 @@ extension FpdartOnIterable<T> on Iterable<T> {
 
   // Simpler version of [_dropRightHelper] for single element drop.
   static Iterable<E> _dropLastHelper<E>(Iterable<E> elements) sync* {
-    var it = elements.iterator;
+    final it = elements.iterator;
     if (!it.moveNext()) return;
     var last = it.current;
     while (it.moveNext()) {
-      var element = last;
+      final element = last;
       last = it.current;
       yield element;
     }
@@ -86,14 +86,14 @@ extension FpdartOnIterable<T> on Iterable<T> {
 
   static Iterable<E> _dropRightHelper<E>(
       Iterable<E> elements, int count) sync* {
-    var it = elements.iterator;
-    var queue = Queue<E>();
+    final it = elements.iterator;
+    final queue = Queue<E>();
     for (var i = 0; i < count; i++) {
       if (!it.moveNext()) return;
       queue.add(it.current);
     }
     while (it.moveNext()) {
-      var element = queue.removeFirst();
+      final element = queue.removeFirst();
       queue.add(it.current);
       yield element;
     }
@@ -108,7 +108,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
   /// Returns the list of those elements that satisfy `test`.
   Iterable<T> filterWithIndex(bool Function(T t, int index) test) sync* {
     var index = 0;
-    for (var value in this) {
+    for (final value in this) {
       if (test(value, index)) {
         yield value;
       }
@@ -188,7 +188,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
   ///
   /// Returns `None` if no such element.
   Option<T> lookupEq(Eq<T> eq, T element) {
-    for (var e in this) {
+    for (final e in this) {
       if (eq.eqv(e, element)) return some(e);
     }
     return const None();
@@ -209,7 +209,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
   ) {
     var index = 0;
     var value = initialValue;
-    for (var element in this) {
+    for (final element in this) {
       value = combine(value, element, index);
       index += 1;
     }
@@ -232,8 +232,8 @@ extension FpdartOnIterable<T> on Iterable<T> {
     C Function(T t, B b) combine,
     Iterable<B> iterable,
   ) sync* {
-    var it = iterator;
-    var otherIt = iterable.iterator;
+    final it = iterator;
+    final otherIt = iterable.iterator;
     while (it.moveNext() && otherIt.moveNext()) {
       yield combine(it.current, otherIt.current);
     }
@@ -255,7 +255,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
   ///
   /// Note: The element is added **before** an equal element already in the [Iterable].
   Iterable<T> insertBy(Order<T> order, T element) sync* {
-    var it = iterator;
+    final it = iterator;
     while (it.moveNext()) {
       if (order.compare(it.current, element) < 0) {
         yield it.current;
@@ -283,8 +283,8 @@ extension FpdartOnIterable<T> on Iterable<T> {
     Order<A> order,
     T element,
   ) sync* {
-    var it = iterator;
-    var elementValue = extract(element);
+    final it = iterator;
+    final elementValue = extract(element);
     while (it.moveNext()) {
       if (order.compare(extract(it.current), elementValue) < 0) {
         yield it.current;
@@ -302,7 +302,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
   /// Remove the **first occurrence** of `element` from this [Iterable].
   Iterable<T> delete(T element) sync* {
     var deleted = false;
-    for (var current in this) {
+    for (final current in this) {
       if (deleted || current != element) {
         yield current;
       } else {
@@ -315,7 +315,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
   /// element in the mapping function (`toElement`).
   Iterable<B> mapWithIndex<B>(B Function(T t, int index) toElement) sync* {
     var index = 0;
-    for (var value in this) {
+    for (final value in this) {
       yield toElement(value, index);
       index += 1;
     }
@@ -327,7 +327,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
     Iterable<B> Function(T t, int index) toElements,
   ) sync* {
     var index = 0;
-    for (var value in this) {
+    for (final value in this) {
       yield* toElements(value, index);
       index += 1;
     }
@@ -337,9 +337,9 @@ extension FpdartOnIterable<T> on Iterable<T> {
   ///
   /// If the list is empty, return [None].
   Option<T> maximumBy(Order<T> order) {
-    var it = iterator;
+    final it = iterator;
     if (it.moveNext()) {
-      T min = it.current;
+      var min = it.current;
       while (it.moveNext()) {
         if (order.compare(it.current, min) > 0) {
           min = it.current;
@@ -354,9 +354,9 @@ extension FpdartOnIterable<T> on Iterable<T> {
   ///
   /// If the list is empty, return [None].
   Option<T> minimumBy(Order<T> order) {
-    var it = iterator;
+    final it = iterator;
     if (it.moveNext()) {
-      T min = it.current;
+      var min = it.current;
       while (it.moveNext()) {
         if (order.compare(it.current, min) < 0) {
           min = it.current;
@@ -379,7 +379,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
     // If it's not important that [iterable] can change between
     // `element`s, consider creating a set from it first,
     // for faster `contains`.
-    for (var element in this) {
+    for (final element in this) {
       if (iterable.contains(element)) yield element;
     }
   }
@@ -387,7 +387,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
   /// Return an [Iterable] containing the values of this [Iterable] not included
   /// in `other` based on `eq`.
   Iterable<T> difference(Eq<T> eq, Iterable<T> other) sync* {
-    for (var element in this) {
+    for (final element in this) {
       if (!other.any((e) => eq.eqv(e, element))) {
         yield element;
       }
@@ -396,7 +396,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
 
   /// Return an [Iterable] placing an `middle` in between elements of the this [Iterable].
   Iterable<T> intersperse(T middle) sync* {
-    var it = iterator;
+    final it = iterator;
     if (!it.moveNext()) return;
     yield it.current;
     while (it.moveNext()) {

--- a/packages/fpdart/lib/src/extension/iterable_extension.dart
+++ b/packages/fpdart/lib/src/extension/iterable_extension.dart
@@ -423,14 +423,16 @@ extension FpdartOnIterable<T> on Iterable<T> {
       sortWith(getDate, Order.orderDate);
 
   /// Optional version of [elementAt].
-  Option<T> elementAtOption(int index) => Option.fromNullable(elementAtOrNull(index));
+  Option<T> elementAtOption(int index) =>
+      Option.fromNullable(elementAtOrNull(index));
 
   /// Optional version of [singleWhereOrNull].
-  Option<T> singleWhereOption(bool Function(T element) test) => Option.fromNullable(singleWhereOrNull(test));
+  Option<T> singleWhereOption(bool Function(T element) test) =>
+      Option.fromNullable(singleWhereOrNull(test));
 
   /// Optional version of [lastWhereOrNull].
-  Option<T> lastWhereOption(bool Function(T element) test) => Option.fromNullable(lastWhereOrNull(test));
-
+  Option<T> lastWhereOption(bool Function(T element) test) =>
+      Option.fromNullable(lastWhereOrNull(test));
 }
 
 /// Functional programming functions on `Iterable<Iterable<T>>` using `fpdart`.

--- a/packages/fpdart/lib/src/extension/iterable_extension.dart
+++ b/packages/fpdart/lib/src/extension/iterable_extension.dart
@@ -27,6 +27,9 @@ extension FpdartOnIterable<T> on Iterable<T> {
   /// Same as `head`.
   Option<T> get firstOption => head;
 
+  /// Optional version of [singleOrNull].
+  Option<T> get singleOption => Option.fromNullable(singleOrNull);
+
   /// Get the last element of the [Iterable].
   /// If the [Iterable] is empty, return [None].
   ///
@@ -417,6 +420,16 @@ extension FpdartOnIterable<T> on Iterable<T> {
   /// Sorting [DateTime] in **ascending** order (older dates first).
   List<T> sortWithDate(DateTime Function(T instance) getDate) =>
       sortWith(getDate, Order.orderDate);
+
+  /// Optional version of [elementAt].
+  Option<T> elementAtOption(int index) => Option.fromNullable(elementAt(index));
+
+  /// Optional version of [singleWhere].
+  Option<T> singleWhereOption(bool Function(T element) test) => Option.fromNullable(singleWhere(test));
+
+  /// Optional version of [lastWhere].
+  Option<T> lastWhereOption(bool Function(T element) test) => Option.fromNullable(lastWhere(test));
+
 }
 
 /// Functional programming functions on `Iterable<Iterable<T>>` using `fpdart`.

--- a/packages/fpdart/lib/src/extension/iterable_extension.dart
+++ b/packages/fpdart/lib/src/extension/iterable_extension.dart
@@ -56,7 +56,7 @@ extension FpdartOnIterable<T> on Iterable<T> {
   /// as if this iterable has only one element.
   Option<Iterable<T>> get init {
     if (isEmpty) return const None();
-    return some(this.dropRight(1));
+    return some(dropRight(1));
   }
 
   /// Drops the last [count] element of this iterable.

--- a/packages/fpdart/lib/src/extension/iterable_extension.dart
+++ b/packages/fpdart/lib/src/extension/iterable_extension.dart
@@ -1,5 +1,4 @@
 import 'dart:collection';
-import 'package:collection/collection.dart';
 
 import '../function.dart';
 import '../option.dart';
@@ -424,15 +423,36 @@ extension FpdartOnIterable<T> on Iterable<T> {
 
   /// Optional version of [elementAt].
   Option<T> elementAtOption(int index) =>
-      Option.fromNullable(elementAtOrNull(index));
+      Option.fromNullable(skip(index).firstOrNull);
 
   /// Optional version of [singleWhereOrNull].
-  Option<T> singleWhereOption(bool Function(T element) test) =>
-      Option.fromNullable(singleWhereOrNull(test));
+  Option<T> singleWhereOption(bool Function(T element) test) {
+    T? result;
+    var found = false;
+    for (final element in this) {
+      if (test(element)) {
+        if (!found) {
+          result = element;
+          found = true;
+        } else {
+          result = null;
+          break;
+        }
+      }
+    }
+
+    return Option.fromNullable(result);
+  }
 
   /// Optional version of [lastWhereOrNull].
-  Option<T> lastWhereOption(bool Function(T element) test) =>
-      Option.fromNullable(lastWhereOrNull(test));
+  Option<T> lastWhereOption(bool Function(T element) test) {
+    T? result;
+    for (final element in this) {
+      if (test(element)) result = element;
+    }
+
+    return Option.fromNullable(result);
+  }
 }
 
 /// Functional programming functions on `Iterable<Iterable<T>>` using `fpdart`.

--- a/packages/fpdart/lib/src/extension/iterable_extension.dart
+++ b/packages/fpdart/lib/src/extension/iterable_extension.dart
@@ -429,15 +429,12 @@ extension FpdartOnIterable<T> on Iterable<T> {
   Option<T> singleWhereOption(bool Function(T element) test) {
     T? result;
     var found = false;
+
     for (final element in this) {
       if (test(element)) {
-        if (!found) {
-          result = element;
-          found = true;
-        } else {
-          result = null;
-          break;
-        }
+        if (found) return const Option.none();
+        result = element;
+        found = true;
       }
     }
 

--- a/packages/fpdart/lib/src/extension/iterable_extension.dart
+++ b/packages/fpdart/lib/src/extension/iterable_extension.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'package:collection/collection.dart';
 
 import '../function.dart';
 import '../option.dart';
@@ -424,11 +425,11 @@ extension FpdartOnIterable<T> on Iterable<T> {
   /// Optional version of [elementAt].
   Option<T> elementAtOption(int index) => Option.fromNullable(elementAt(index));
 
-  /// Optional version of [singleWhere].
-  Option<T> singleWhereOption(bool Function(T element) test) => Option.fromNullable(singleWhere(test));
+  /// Optional version of [singleWhereOrNull].
+  Option<T> singleWhereOption(bool Function(T element) test) => Option.fromNullable(singleWhereOrNull(test));
 
-  /// Optional version of [lastWhere].
-  Option<T> lastWhereOption(bool Function(T element) test) => Option.fromNullable(lastWhere(test));
+  /// Optional version of [lastWhereOrNull].
+  Option<T> lastWhereOption(bool Function(T element) test) => Option.fromNullable(lastWhereOrNull(test));
 
 }
 

--- a/packages/fpdart/lib/src/extension/list_extension.dart
+++ b/packages/fpdart/lib/src/extension/list_extension.dart
@@ -17,7 +17,7 @@ extension FpdartOnList<T> on List<T> {
     B Function(B previousValue, T element) combine,
   ) {
     var value = initialValue;
-    for (var element in reversed) {
+    for (final element in reversed) {
       value = combine(value, element);
     }
     return value;
@@ -31,7 +31,7 @@ extension FpdartOnList<T> on List<T> {
   ) {
     var index = 0;
     var value = initialValue;
-    for (var element in reversed) {
+    for (final element in reversed) {
       value = combine(value, element, index);
       index += 1;
     }

--- a/packages/fpdart/lib/src/extension/map_extension.dart
+++ b/packages/fpdart/lib/src/extension/map_extension.dart
@@ -12,33 +12,33 @@ extension FpdartOnMap<K, V> on Map<K, V> {
   /// Convert each **value** of the [Map] using
   /// the `update` function and returns a new [Map].
   Map<K, A> mapValue<A>(A Function(V value) update) =>
-      {for (var MapEntry(:key, :value) in entries) key: update(value)};
+      {for (final MapEntry(:key, :value) in entries) key: update(value)};
 
   /// Convert each **value** of the [Map] using
   /// the `update` function and returns a new [Map].
   Map<K, A> mapWithIndex<A>(A Function(V value, int index) update) => {
-        for (var (index, MapEntry(:key, :value)) in entries.indexed)
+        for (final (index, MapEntry(:key, :value)) in entries.indexed)
           key: update(value, index)
       };
 
   /// Returns a new [Map] containing all the elements of this [Map]
   /// where the **value** satisfies `test`.
   Map<K, V> filter(bool Function(V value) test) => {
-        for (var MapEntry(:key, :value) in entries)
+        for (final MapEntry(:key, :value) in entries)
           if (test(value)) key: value
       };
 
   /// Returns a new [Map] containing all the elements of this [Map]
   /// where the **value** satisfies `test`.
   Map<K, V> filterWithIndex(bool Function(V value, int index) test) => {
-        for (var (index, MapEntry(:key, :value)) in entries.indexed)
+        for (final (index, MapEntry(:key, :value)) in entries.indexed)
           if (test(value, index)) key: value
       };
 
   /// Returns a new [Map] containing all the elements of this [Map]
   /// where **key/value** satisfies `test`.
   Map<K, V> filterWithKey(bool Function(K key, V value) test) => {
-        for (var (MapEntry(:key, :value)) in entries)
+        for (final (MapEntry(:key, :value)) in entries)
           if (test(key, value)) key: value
       };
 
@@ -48,13 +48,13 @@ extension FpdartOnMap<K, V> on Map<K, V> {
     bool Function(K key, V value, int index) test,
   ) =>
       {
-        for (var (index, MapEntry(:key, :value)) in entries.indexed)
+        for (final (index, MapEntry(:key, :value)) in entries.indexed)
           if (test(key, value, index)) key: value
       };
 
   /// Get the value at given `key` if present, otherwise return [None].
   Option<V> lookup(K key) {
-    var value = this[key];
+    final value = this[key];
     if (value != null) return some(value);
     if (containsKey(key)) return some(value as V);
     return const None();
@@ -73,7 +73,7 @@ extension FpdartOnMap<K, V> on Map<K, V> {
 
   /// Get the value at given `key` if present using `eq`, otherwise return [None].
   Option<V> lookupEq(Eq<K> eq, K key) {
-    for (var entry in entries) {
+    for (final entry in entries) {
       if (eq.eqv(entry.key, key)) return some(entry.value);
     }
     return const None();
@@ -81,7 +81,7 @@ extension FpdartOnMap<K, V> on Map<K, V> {
 
   /// Get the value and key at given `key` if present using `eq`, otherwise return [None].
   Option<(K, V)> lookupWithKeyEq(Eq<K> eq, K key) {
-    for (var entry in entries) {
+    for (final entry in entries) {
       if (eq.eqv(entry.key, key)) return some((entry.key, entry.value));
     }
     return const None();
@@ -123,11 +123,11 @@ extension FpdartOnMap<K, V> on Map<K, V> {
     V Function(V value) update,
     K key,
   ) {
-    for (var entryKey in keys) {
+    for (final entryKey in keys) {
       if (eq.eqv(entryKey, key)) {
         // At least one equal key exists in map.
         return some({
-          for (var entry in entries)
+          for (final entry in entries)
             entry.key:
                 eq.eqv(entry.key, key) ? update(entry.value) : entry.value
         });
@@ -319,9 +319,9 @@ extension FpdartOnMap<K, V> on Map<K, V> {
     V Function(V x, V y) combine,
     Map<K, V> map,
   ) {
-    var result = {...this};
-    for (var entry in map.entries) {
-      if (lookupKeyEq(eq, entry.key) case Some(value: var key)) {
+    final result = {...this};
+    for (final entry in map.entries) {
+      if (lookupKeyEq(eq, entry.key) case Some(value: final key)) {
         result.update(key, (v) => combine(entry.value, v));
       } else {
         result[entry.key] = entry.value;
@@ -337,8 +337,8 @@ extension FpdartOnMap<K, V> on Map<K, V> {
     Map<K, V> map,
   ) =>
       {
-        for (var entry in map.entries)
-          if (lookupEq(eq, entry.key) case Some(:var value))
+        for (final entry in map.entries)
+          if (lookupEq(eq, entry.key) case Some(:final value))
             entry.key: combine(value, entry.value)
       };
 

--- a/packages/fpdart/lib/src/extension/task_extension.dart
+++ b/packages/fpdart/lib/src/extension/task_extension.dart
@@ -5,9 +5,9 @@ import '../task_either.dart';
 import '../task_option.dart';
 
 extension CompositionOptionExtension<T> on Task<Option<T>> {
-  TaskOption<T> toCompositionTaskOption() => TaskOption.fromComposition(this);
+  TaskOption<T> toTaskOption() => TaskOption.fromTaskFlatten(this);
 }
 
 extension CompositionEitherExtension<L, R> on Task<Either<L, R>> {
-  TaskEither<L, R> toCompositionTaskEither() => TaskEither.fromComposition(this);
+  TaskEither<L, R> toTaskEither() => TaskEither.fromTaskFlatten(this);
 }

--- a/packages/fpdart/lib/src/extension/task_extension.dart
+++ b/packages/fpdart/lib/src/extension/task_extension.dart
@@ -1,0 +1,13 @@
+import '../either.dart';
+import '../option.dart';
+import '../task.dart';
+import '../task_either.dart';
+import '../task_option.dart';
+
+extension CompositionOptionExtension<T> on Task<Option<T>> {
+  TaskOption<T> toCompositionTaskOption() => TaskOption.fromComposition(this);
+}
+
+extension CompositionEitherExtension<L, R> on Task<Either<L, R>> {
+  TaskEither<L, R> toCompositionTaskEither() => TaskEither.fromComposition(this);
+}

--- a/packages/fpdart/lib/src/extension/task_extension.dart
+++ b/packages/fpdart/lib/src/extension/task_extension.dart
@@ -5,9 +5,9 @@ import '../task_either.dart';
 import '../task_option.dart';
 
 extension CompositionOptionExtension<T> on Task<Option<T>> {
-  TaskOption<T> toTaskOption() => TaskOption.fromTaskFlatten(this);
+  TaskOption<T> toTaskOptionFlat() => TaskOption.fromTaskFlatten(this);
 }
 
 extension CompositionEitherExtension<L, R> on Task<Either<L, R>> {
-  TaskEither<L, R> toTaskEither() => TaskEither.fromTaskFlatten(this);
+  TaskEither<L, R> toTaskEitherFlat() => TaskEither.fromTaskFlatten(this);
 }

--- a/packages/fpdart/lib/src/function.dart
+++ b/packages/fpdart/lib/src/function.dart
@@ -41,6 +41,8 @@ Future<T> identityFuture<T>(T a) => Future.value(a);
 /// print(c('any')); // -> 10
 /// print(c(112.12)); // -> 10
 /// ```
+// `dynamic b` is just a placeholder
+//ignore: avoid_annotating_with_dynamic
 A Function(dynamic b) constF<A>(A a) => <B>(B b) => a;
 
 /// {@template fpdart_string_extension_to_num_option}

--- a/packages/fpdart/lib/src/io.dart
+++ b/packages/fpdart/lib/src/io.dart
@@ -1,7 +1,3 @@
-// Should always be available.
-//ignore: depend_on_referenced_packages
-import 'package:meta/meta.dart';
-
 import 'either.dart';
 import 'function.dart';
 import 'io_either.dart';
@@ -23,7 +19,6 @@ typedef DoFunctionIO<A> = A Function(DoAdapterIO $);
 /// Tag the [HKT] interface for the actual [Option].
 abstract final class _IOHKT {}
 
-@immutable
 /// `IO<A>` represents a **non-deterministic synchronous** computation that
 /// can **cause side effects**, yields a value of type `A` and **never fails**.
 ///

--- a/packages/fpdart/lib/src/io.dart
+++ b/packages/fpdart/lib/src/io.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import 'either.dart';
 import 'function.dart';
 import 'io_either.dart';
@@ -19,10 +21,12 @@ typedef DoFunctionIO<A> = A Function(DoAdapterIO $);
 /// Tag the [HKT] interface for the actual [Option].
 abstract final class _IOHKT {}
 
+@immutable
 /// `IO<A>` represents a **non-deterministic synchronous** computation that
 /// can **cause side effects**, yields a value of type `A` and **never fails**.
 ///
 /// If you want to represent a synchronous computation that may fail, see [IOEither].
+///
 final class IO<A> extends HKT<_IOHKT, A>
     with Functor<_IOHKT, A>, Applicative<_IOHKT, A>, Monad<_IOHKT, A> {
   final A Function() _run;

--- a/packages/fpdart/lib/src/io.dart
+++ b/packages/fpdart/lib/src/io.dart
@@ -1,3 +1,5 @@
+// Should always be available.
+//ignore: depend_on_referenced_packages
 import 'package:meta/meta.dart';
 
 import 'either.dart';

--- a/packages/fpdart/lib/src/io_either.dart
+++ b/packages/fpdart/lib/src/io_either.dart
@@ -127,8 +127,7 @@ final class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
       a.flatMap((f) => flatMap((v) => pure(f(v))));
 
   /// Change this [IOEither] from `IOEither<L, R>` to `IOEither<R, L>`.
-  IOEither<R, L> swap() =>
-      IOEither(() => run().match(Right.new, Left.new));
+  IOEither<R, L> swap() => IOEither(() => run().match(Right.new, Left.new));
 
   /// When this [IOEither] returns [Right], then return the current [IOEither].
   /// Otherwise return the result of `orElse`.

--- a/packages/fpdart/lib/src/io_either.dart
+++ b/packages/fpdart/lib/src/io_either.dart
@@ -9,7 +9,7 @@ import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
-final class _IOEitherThrow<L> {
+final class _IOEitherThrow<L> implements Exception {
   final L value;
   const _IOEitherThrow(this.value);
 }

--- a/packages/fpdart/lib/src/io_either.dart
+++ b/packages/fpdart/lib/src/io_either.dart
@@ -58,7 +58,7 @@ final class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
   IOEither<L, C> flatMap<C>(covariant IOEither<L, C> Function(R r) f) =>
       IOEither(
         () => run().match(
-          (l) => Either.left(l),
+          Either.left,
           (r) => f(r).run(),
         ),
       );
@@ -70,7 +70,7 @@ final class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
   TaskEither<L, C> flatMapTask<C>(TaskEither<L, C> Function(R r) f) =>
       TaskEither(
         () async => run().match(
-          (l) => Either.left(l),
+          Either.left,
           (r) => f(r).run(),
         ),
       );
@@ -110,7 +110,7 @@ final class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
 
   /// Change the value in the [Left] of [IOEither].
   IOEither<C, R> mapLeft<C>(C Function(L l) f) => IOEither(
-        () => (run()).match((l) => Either.left(f(l)), Either.of),
+        () => run().match((l) => Either.left(f(l)), Either.of),
       );
 
   /// Define two functions to change both the [Left] and [Right] value of the
@@ -128,7 +128,7 @@ final class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
 
   /// Change this [IOEither] from `IOEither<L, R>` to `IOEither<R, L>`.
   IOEither<R, L> swap() =>
-      IOEither(() => run().match((l) => Right(l), (r) => Left(r)));
+      IOEither(() => run().match(Right.new, Left.new));
 
   /// When this [IOEither] returns [Right], then return the current [IOEither].
   /// Otherwise return the result of `orElse`.

--- a/packages/fpdart/lib/src/io_either.dart
+++ b/packages/fpdart/lib/src/io_either.dart
@@ -242,7 +242,7 @@ final class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
       IOEither<L, R>(() {
         try {
           return Right<L, R>(run());
-        } catch (error, stack) {
+        } on Exception catch (error, stack) {
           return Left<L, R>(onError(error, stack));
         }
       });

--- a/packages/fpdart/lib/src/io_either.dart
+++ b/packages/fpdart/lib/src/io_either.dart
@@ -241,7 +241,7 @@ final class IOEither<L, R> extends HKT2<_IOEitherHKT, L, R>
       IOEither<L, R>(() {
         try {
           return Right<L, R>(run());
-        } on Exception catch (error, stack) {
+        } catch (error, stack) {
           return Left<L, R>(onError(error, stack));
         }
       });

--- a/packages/fpdart/lib/src/io_option.dart
+++ b/packages/fpdart/lib/src/io_option.dart
@@ -198,7 +198,7 @@ final class IOOption<R> extends HKT<_IOOptionHKT, R>
   factory IOOption.tryCatch(R Function() run) => IOOption<R>(() {
         try {
           return Option.of(run());
-        } on Exception catch (_) {
+        } catch (_) {
           return const Option.none();
         }
       });

--- a/packages/fpdart/lib/src/io_option.dart
+++ b/packages/fpdart/lib/src/io_option.dart
@@ -198,7 +198,7 @@ final class IOOption<R> extends HKT<_IOOptionHKT, R>
   factory IOOption.tryCatch(R Function() run) => IOOption<R>(() {
         try {
           return Option.of(run());
-        } catch (_) {
+        } on Exception catch (_) {
           return const Option.none();
         }
       });

--- a/packages/fpdart/lib/src/io_option.dart
+++ b/packages/fpdart/lib/src/io_option.dart
@@ -12,7 +12,7 @@ import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
-final class _IOOptionThrow {
+final class _IOOptionThrow implements Exception {
   const _IOOptionThrow();
 }
 

--- a/packages/fpdart/lib/src/io_ref.dart
+++ b/packages/fpdart/lib/src/io_ref.dart
@@ -1,4 +1,6 @@
+import '../fpdart.dart' show State;
 import 'io.dart';
+import 'state.dart' show State;
 import 'typeclass/eq.dart';
 import 'typedef.dart';
 import 'unit.dart';
@@ -44,7 +46,7 @@ final class IORef<T> {
 }
 
 /// [Eq] instance to compare [IORef]s using pointer equality
-final ioRefEq = Eq.instance<IORef<Object?>>((a, b) => identical(a, b));
+final ioRefEq = Eq.instance<IORef<Object?>>(identical);
 
 /// {@macro create_io_ref}
 IO<IORef<T>> newIORef<T>(T initial) => IORef.create(initial);

--- a/packages/fpdart/lib/src/option.dart
+++ b/packages/fpdart/lib/src/option.dart
@@ -422,7 +422,7 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   factory Option.tryCatch(T Function() f) {
     try {
       return Some(f());
-    } catch (_) {
+    } on Exception catch (_) {
       return const Option.none();
     }
   }

--- a/packages/fpdart/lib/src/option.dart
+++ b/packages/fpdart/lib/src/option.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import 'either.dart';
 import 'extension/option_extension.dart';
 import 'function.dart';
@@ -499,6 +501,7 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   Object? toJson(Object? Function(T) toJsonT);
 }
 
+@immutable
 class Some<T> extends Option<T> {
   final T _value;
   const Some(this._value);
@@ -564,6 +567,7 @@ class Some<T> extends Option<T> {
   TaskOption<T> toTaskOption() => TaskOption.of(_value);
 }
 
+@immutable
 class None extends Option<Never> {
   const None();
 

--- a/packages/fpdart/lib/src/option.dart
+++ b/packages/fpdart/lib/src/option.dart
@@ -127,8 +127,8 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// ```
   @override
   Option<B> ap<B>(covariant Option<B Function(T t)> a) => a.match(
-        () => Option<B>.none(),
-        (f) => map(f),
+        Option<B>.none,
+        map,
       );
 
   /// Return a [Some] containing the value `b`.
@@ -363,7 +363,7 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// Build a [Option] from a [Either] by returning [Some] when `either` is [Right],
   /// [None] otherwise.
   static Option<R> fromEither<L, R>(Either<L, R> either) =>
-      either.match((_) => const Option.none(), (r) => Some(r));
+      either.match((_) => const Option.none(), Some.new);
 
   /// {@template fpdart_safe_cast_option}
   /// Safely cast a value to type `T`.

--- a/packages/fpdart/lib/src/option.dart
+++ b/packages/fpdart/lib/src/option.dart
@@ -37,7 +37,7 @@ Option<T> optionOf<T>(T? t) => Option.fromNullable(t);
 /// Same as initializing `Option.fromPredicate(value, predicate)`.
 Option<T> option<T>(T value, bool Function(T) predicate) => Option.fromPredicate(value, predicate);
 
-final class _OptionThrow {
+final class _OptionThrow implements Exception {
   const _OptionThrow();
 }
 

--- a/packages/fpdart/lib/src/option.dart
+++ b/packages/fpdart/lib/src/option.dart
@@ -33,14 +33,16 @@ Option<T> optionOf<T>(T? t) => Option.fromNullable(t);
 /// [None] otherwise.
 ///
 /// Same as initializing `Option.fromPredicate(value, predicate)`.
-Option<T> option<T>(T value, bool Function(T) predicate) => Option.fromPredicate(value, predicate);
+Option<T> option<T>(T value, bool Function(T) predicate) =>
+    Option.fromPredicate(value, predicate);
 
 final class _OptionThrow implements Exception {
   const _OptionThrow();
 }
 
 typedef DoAdapterOption = A Function<A>(Option<A>);
-A _doAdapter<A>(Option<A> option) => option.getOrElse(() => throw const _OptionThrow());
+A _doAdapter<A>(Option<A> option) =>
+    option.getOrElse(() => throw const _OptionThrow());
 
 typedef DoFunctionOption<A> = A Function(DoAdapterOption $);
 
@@ -187,7 +189,8 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   ///   Option.of(456),
   /// );
   /// ```
-  Option<B> flatMapNullable<B>(B? Function(T t) f) => flatMap((t) => Option.fromNullable(f(t)));
+  Option<B> flatMapNullable<B>(B? Function(T t) f) =>
+      flatMap((t) => Option.fromNullable(f(t)));
 
   /// Return a new [Option] that calls [Option.tryCatch] with the given function [f].
   ///
@@ -198,7 +201,8 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   ///   Option.of(456),
   /// );
   /// ```
-  Option<B> flatMapThrowable<B>(B Function(T t) f) => flatMap((t) => Option.tryCatch(() => f(t)));
+  Option<B> flatMapThrowable<B>(B Function(T t) f) =>
+      flatMap((t) => Option.tryCatch(() => f(t)));
 
   /// Change the value of [Option] from type `T` to type `Z` based on the
   /// value of `Option<T>` using function `f`.
@@ -212,7 +216,8 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// If this [Option] is a [Some] and calling `f` returns `true`, then return this [Some].
   /// Otherwise return [None].
   @override
-  Option<T> filter(bool Function(T t) f) => flatMap((t) => f(t) ? this : const Option.none());
+  Option<T> filter(bool Function(T t) f) =>
+      flatMap((t) => f(t) ? this : const Option.none());
 
   /// If this [Option] is a [Some] and calling `f` returns [Some], then return this [Some].
   /// Otherwise return [None].
@@ -224,7 +229,8 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// - if `f` applied to its value returns `false`, then the tuple contains this [Option] as first value
   /// Otherwise the tuple contains both [None].
   @override
-  (Option<T>, Option<T>) partition(bool Function(T t) f) => (filter((a) => !f(a)), filter(f));
+  (Option<T>, Option<T>) partition(bool Function(T t) f) =>
+      (filter((a) => !f(a)), filter(f));
 
   /// Return a record that contains as first value a [Some] when `f` returns [Left],
   /// otherwise the [Some] will be the second value of the tuple.
@@ -239,7 +245,8 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// [_].andThen(() => [🍎]) -> [_]
   /// ```
   @override
-  Option<B> andThen<B>(covariant Option<B> Function() then) => flatMap((_) => then());
+  Option<B> andThen<B>(covariant Option<B> Function() then) =>
+      flatMap((_) => then());
 
   /// Chain multiple [Option]s.
   @override
@@ -255,8 +262,8 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// value of type `C` of a second [Option], and the value of type `D`
   /// of a third [Option].
   @override
-  Option<E> map3<C, D, E>(
-          covariant Option<C> mc, covariant Option<D> md, E Function(T t, C c, D d) f) =>
+  Option<E> map3<C, D, E>(covariant Option<C> mc, covariant Option<D> md,
+          E Function(T t, C c, D d) f) =>
       flatMap((a) => mc.flatMap((c) => md.map((d) => f(a, c, d))));
 
   /// {@template fpdart_option_match}
@@ -277,7 +284,8 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// ```
   ///
   /// Same as `match`.
-  B fold<B>(B Function() onNone, B Function(T t) onSome) => match(onNone, onSome);
+  B fold<B>(B Function() onNone, B Function(T t) onSome) =>
+      match(onNone, onSome);
 
   /// Return `true` when value is [Some].
   bool isSome();
@@ -368,7 +376,8 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// instead of `Option.safeCast`), otherwise this will always return [Some]!
   // `dynamic`s are use for safe-casting
   //ignore: avoid_annotating_with_dynamic
-  factory Option.safeCast(dynamic value) => Option.safeCastStrict<T, dynamic>(value);
+  factory Option.safeCast(dynamic value) =>
+      Option.safeCastStrict<T, dynamic>(value);
 
   /// {@macro fpdart_safe_cast_option}
   ///
@@ -422,7 +431,8 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   ///
   /// The value on the left of the [Either] will be the first value of the tuple,
   /// while the right value of the [Either] will be the second of the tuple.
-  static (Option<A>, Option<B>) separate<A, B>(Option<Either<A, B>> m) => m.match(
+  static (Option<A>, Option<B>) separate<A, B>(Option<Either<A, B>> m) =>
+      m.match(
         () => (const Option.none(), const Option.none()),
         (either) => (either.getLeft(), either.getRight()),
       );
@@ -434,7 +444,9 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// It returns `false` in all other cases.
   static Eq<Option<T>> getEq<T>(Eq<T> eq) => Eq.instance((a1, a2) =>
       a1 == a2 ||
-      a1.flatMap((j1) => a2.flatMap((j2) => Some(eq.eqv(j1, j2)))).getOrElse(() => false));
+      a1
+          .flatMap((j1) => a2.flatMap((j2) => Some(eq.eqv(j1, j2))))
+          .getOrElse(() => false));
 
   /// Build an instance of [Monoid] in which the `empty` value is [None] and the
   /// `combine` function is based on the **first** [Option] if it is [Some], otherwise the second.
@@ -451,11 +463,12 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// if they are both [Some].
   ///
   /// If one of the [Option] is [None], then calling `combine` returns [None].
-  static Monoid<Option<T>> getMonoid<T>(Semigroup<T> semigroup) => Monoid.instance(
-      const Option.none(),
-      (a1, a2) => a1.flatMap((v1) => a2.flatMap(
-            (v2) => Some(semigroup.combine(v1, v2)),
-          )));
+  static Monoid<Option<T>> getMonoid<T>(Semigroup<T> semigroup) =>
+      Monoid.instance(
+          const Option.none(),
+          (a1, a2) => a1.flatMap((v1) => a2.flatMap(
+                (v2) => Some(semigroup.combine(v1, v2)),
+              )));
 
   /// Return an [Order] to order instances of [Option].
   ///
@@ -504,8 +517,8 @@ class Some<T> extends Option<T> {
       flatMap((a) => mc.map((c) => f(a, c)));
 
   @override
-  Option<E> map3<C, D, E>(
-          covariant Option<C> mc, covariant Option<D> md, E Function(T t, C c, D d) f) =>
+  Option<E> map3<C, D, E>(covariant Option<C> mc, covariant Option<D> md,
+          E Function(T t, C c, D d) f) =>
       flatMap((a) => mc.flatMap((c) => md.map((d) => f(a, c, d))));
 
   @override
@@ -561,7 +574,8 @@ class None extends Option<Never> {
   const None();
 
   @override
-  Option<D> map2<C, D>(covariant Option<C> mc, D Function(Never t, C c) f) => this;
+  Option<D> map2<C, D>(covariant Option<C> mc, D Function(Never t, C c) f) =>
+      this;
 
   @override
   Option<E> map3<C, D, E>(

--- a/packages/fpdart/lib/src/option.dart
+++ b/packages/fpdart/lib/src/option.dart
@@ -422,7 +422,7 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   factory Option.tryCatch(T Function() f) {
     try {
       return Some(f());
-    } on Exception catch (_) {
+    } catch (_) {
       return const Option.none();
     }
   }

--- a/packages/fpdart/lib/src/option.dart
+++ b/packages/fpdart/lib/src/option.dart
@@ -35,16 +35,14 @@ Option<T> optionOf<T>(T? t) => Option.fromNullable(t);
 /// [None] otherwise.
 ///
 /// Same as initializing `Option.fromPredicate(value, predicate)`.
-Option<T> option<T>(T value, bool Function(T) predicate) =>
-    Option.fromPredicate(value, predicate);
+Option<T> option<T>(T value, bool Function(T) predicate) => Option.fromPredicate(value, predicate);
 
 final class _OptionThrow {
   const _OptionThrow();
 }
 
 typedef DoAdapterOption = A Function<A>(Option<A>);
-A _doAdapter<A>(Option<A> option) =>
-    option.getOrElse(() => throw const _OptionThrow());
+A _doAdapter<A>(Option<A> option) => option.getOrElse(() => throw const _OptionThrow());
 
 typedef DoFunctionOption<A> = A Function(DoAdapterOption $);
 
@@ -191,8 +189,7 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   ///   Option.of(456),
   /// );
   /// ```
-  Option<B> flatMapNullable<B>(B? Function(T t) f) =>
-      flatMap((t) => Option.fromNullable(f(t)));
+  Option<B> flatMapNullable<B>(B? Function(T t) f) => flatMap((t) => Option.fromNullable(f(t)));
 
   /// Return a new [Option] that calls [Option.tryCatch] with the given function [f].
   ///
@@ -203,8 +200,7 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   ///   Option.of(456),
   /// );
   /// ```
-  Option<B> flatMapThrowable<B>(B Function(T t) f) =>
-      flatMap((t) => Option.tryCatch(() => f(t)));
+  Option<B> flatMapThrowable<B>(B Function(T t) f) => flatMap((t) => Option.tryCatch(() => f(t)));
 
   /// Change the value of [Option] from type `T` to type `Z` based on the
   /// value of `Option<T>` using function `f`.
@@ -218,8 +214,7 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// If this [Option] is a [Some] and calling `f` returns `true`, then return this [Some].
   /// Otherwise return [None].
   @override
-  Option<T> filter(bool Function(T t) f) =>
-      flatMap((t) => f(t) ? this : const Option.none());
+  Option<T> filter(bool Function(T t) f) => flatMap((t) => f(t) ? this : const Option.none());
 
   /// If this [Option] is a [Some] and calling `f` returns [Some], then return this [Some].
   /// Otherwise return [None].
@@ -231,8 +226,7 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// - if `f` applied to its value returns `false`, then the tuple contains this [Option] as first value
   /// Otherwise the tuple contains both [None].
   @override
-  (Option<T>, Option<T>) partition(bool Function(T t) f) =>
-      (filter((a) => !f(a)), filter(f));
+  (Option<T>, Option<T>) partition(bool Function(T t) f) => (filter((a) => !f(a)), filter(f));
 
   /// Return a record that contains as first value a [Some] when `f` returns [Left],
   /// otherwise the [Some] will be the second value of the tuple.
@@ -247,8 +241,7 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// [_].andThen(() => [🍎]) -> [_]
   /// ```
   @override
-  Option<B> andThen<B>(covariant Option<B> Function() then) =>
-      flatMap((_) => then());
+  Option<B> andThen<B>(covariant Option<B> Function() then) => flatMap((_) => then());
 
   /// Chain multiple [Option]s.
   @override
@@ -264,8 +257,8 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// value of type `C` of a second [Option], and the value of type `D`
   /// of a third [Option].
   @override
-  Option<E> map3<C, D, E>(covariant Option<C> mc, covariant Option<D> md,
-          E Function(T t, C c, D d) f) =>
+  Option<E> map3<C, D, E>(
+          covariant Option<C> mc, covariant Option<D> md, E Function(T t, C c, D d) f) =>
       flatMap((a) => mc.flatMap((c) => md.map((d) => f(a, c, d))));
 
   /// {@template fpdart_option_match}
@@ -286,8 +279,7 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// ```
   ///
   /// Same as `match`.
-  B fold<B>(B Function() onNone, B Function(T t) onSome) =>
-      match(onNone, onSome);
+  B fold<B>(B Function() onNone, B Function(T t) onSome) => match(onNone, onSome);
 
   /// Return `true` when value is [Some].
   bool isSome();
@@ -376,8 +368,9 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   ///
   /// **Note**: Make sure to specify the type of [Option] (`Option<T>.safeCast`
   /// instead of `Option.safeCast`), otherwise this will always return [Some]!
-  factory Option.safeCast(dynamic value) =>
-      Option.safeCastStrict<T, dynamic>(value);
+  // `dynamic`s are use for safe-casting
+  //ignore: avoid_annotating_with_dynamic
+  factory Option.safeCast(dynamic value) => Option.safeCastStrict<T, dynamic>(value);
 
   /// {@macro fpdart_safe_cast_option}
   ///
@@ -431,8 +424,7 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   ///
   /// The value on the left of the [Either] will be the first value of the tuple,
   /// while the right value of the [Either] will be the second of the tuple.
-  static (Option<A>, Option<B>) separate<A, B>(Option<Either<A, B>> m) =>
-      m.match(
+  static (Option<A>, Option<B>) separate<A, B>(Option<Either<A, B>> m) => m.match(
         () => (const Option.none(), const Option.none()),
         (either) => (either.getLeft(), either.getRight()),
       );
@@ -444,9 +436,7 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// It returns `false` in all other cases.
   static Eq<Option<T>> getEq<T>(Eq<T> eq) => Eq.instance((a1, a2) =>
       a1 == a2 ||
-      a1
-          .flatMap((j1) => a2.flatMap((j2) => Some(eq.eqv(j1, j2))))
-          .getOrElse(() => false));
+      a1.flatMap((j1) => a2.flatMap((j2) => Some(eq.eqv(j1, j2)))).getOrElse(() => false));
 
   /// Build an instance of [Monoid] in which the `empty` value is [None] and the
   /// `combine` function is based on the **first** [Option] if it is [Some], otherwise the second.
@@ -463,12 +453,11 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   /// if they are both [Some].
   ///
   /// If one of the [Option] is [None], then calling `combine` returns [None].
-  static Monoid<Option<T>> getMonoid<T>(Semigroup<T> semigroup) =>
-      Monoid.instance(
-          const Option.none(),
-          (a1, a2) => a1.flatMap((v1) => a2.flatMap(
-                (v2) => Some(semigroup.combine(v1, v2)),
-              )));
+  static Monoid<Option<T>> getMonoid<T>(Semigroup<T> semigroup) => Monoid.instance(
+      const Option.none(),
+      (a1, a2) => a1.flatMap((v1) => a2.flatMap(
+            (v2) => Some(semigroup.combine(v1, v2)),
+          )));
 
   /// Return an [Order] to order instances of [Option].
   ///
@@ -490,7 +479,11 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   ///
   /// Json serialization support for `json_serializable` with `@JsonSerializable`.
   factory Option.fromJson(
+    // nature of JSON
+    //ignore: avoid_annotating_with_dynamic
     dynamic json,
+    // nature of JSON
+    //ignore: avoid_annotating_with_dynamic
     T Function(dynamic json) fromJsonT,
   ) =>
       json != null ? Option.tryCatch(() => fromJsonT(json)) : Option.none();
@@ -514,8 +507,8 @@ class Some<T> extends Option<T> {
       flatMap((a) => mc.map((c) => f(a, c)));
 
   @override
-  Option<E> map3<C, D, E>(covariant Option<C> mc, covariant Option<D> md,
-          E Function(T t, C c, D d) f) =>
+  Option<E> map3<C, D, E>(
+          covariant Option<C> mc, covariant Option<D> md, E Function(T t, C c, D d) f) =>
       flatMap((a) => mc.flatMap((c) => md.map((d) => f(a, c, d))));
 
   @override
@@ -572,8 +565,7 @@ class None extends Option<Never> {
   const None();
 
   @override
-  Option<D> map2<C, D>(covariant Option<C> mc, D Function(Never t, C c) f) =>
-      this;
+  Option<D> map2<C, D>(covariant Option<C> mc, D Function(Never t, C c) f) => this;
 
   @override
   Option<E> map3<C, D, E>(

--- a/packages/fpdart/lib/src/option.dart
+++ b/packages/fpdart/lib/src/option.dart
@@ -1,7 +1,3 @@
-// Should always be available.
-//ignore: depend_on_referenced_packages
-import 'package:meta/meta.dart';
-
 import 'either.dart';
 import 'extension/option_extension.dart';
 import 'function.dart';
@@ -496,7 +492,6 @@ sealed class Option<T> extends HKT<_OptionHKT, T>
   Object? toJson(Object? Function(T) toJsonT);
 }
 
-@immutable
 class Some<T> extends Option<T> {
   final T _value;
   const Some(this._value);
@@ -562,7 +557,6 @@ class Some<T> extends Option<T> {
   TaskOption<T> toTaskOption() => TaskOption.of(_value);
 }
 
-@immutable
 class None extends Option<Never> {
   const None();
 

--- a/packages/fpdart/lib/src/option.dart
+++ b/packages/fpdart/lib/src/option.dart
@@ -1,3 +1,5 @@
+// Should always be available.
+//ignore: depend_on_referenced_packages
 import 'package:meta/meta.dart';
 
 import 'either.dart';

--- a/packages/fpdart/lib/src/reader.dart
+++ b/packages/fpdart/lib/src/reader.dart
@@ -1,3 +1,5 @@
+// Should always be available.
+//ignore: depend_on_referenced_packages
 import 'package:meta/meta.dart';
 
 import 'function.dart';

--- a/packages/fpdart/lib/src/reader.dart
+++ b/packages/fpdart/lib/src/reader.dart
@@ -1,7 +1,3 @@
-// Should always be available.
-//ignore: depend_on_referenced_packages
-import 'package:meta/meta.dart';
-
 import 'function.dart';
 import 'typeclass/applicative.dart';
 import 'typeclass/functor.dart';
@@ -11,7 +7,6 @@ import 'typeclass/monad.dart';
 /// Tag the [HKT2] interface for the actual [Reader].
 abstract final class ReaderHKT {}
 
-@immutable
 /// `Reader<R, A>` allows to read values `A` from a dependency/context `R`
 /// without explicitly passing the dependency between multiple nested
 /// function calls.

--- a/packages/fpdart/lib/src/reader.dart
+++ b/packages/fpdart/lib/src/reader.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import 'function.dart';
 import 'typeclass/applicative.dart';
 import 'typeclass/functor.dart';
@@ -7,6 +9,7 @@ import 'typeclass/monad.dart';
 /// Tag the [HKT2] interface for the actual [Reader].
 abstract final class ReaderHKT {}
 
+@immutable
 /// `Reader<R, A>` allows to read values `A` from a dependency/context `R`
 /// without explicitly passing the dependency between multiple nested
 /// function calls.

--- a/packages/fpdart/lib/src/reader_task.dart
+++ b/packages/fpdart/lib/src/reader_task.dart
@@ -7,8 +7,7 @@ import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
 typedef DoAdapterReaderTask<E> = Future<A> Function<A>(ReaderTask<E, A>);
-DoAdapterReaderTask<E> _doAdapter<E>(E env) =>
-    <A>(task) => task.run(env);
+DoAdapterReaderTask<E> _doAdapter<E>(E env) => <A>(task) => task.run(env);
 
 typedef DoFunctionReaderTask<E, A> = Future<A> Function(
     DoAdapterReaderTask<E> $);

--- a/packages/fpdart/lib/src/reader_task.dart
+++ b/packages/fpdart/lib/src/reader_task.dart
@@ -8,7 +8,7 @@ import 'typeclass/monad.dart';
 
 typedef DoAdapterReaderTask<E> = Future<A> Function<A>(ReaderTask<E, A>);
 DoAdapterReaderTask<E> _doAdapter<E>(E env) =>
-    <A>(ReaderTask<E, A> task) => task.run(env);
+    <A>(task) => task.run(env);
 
 typedef DoFunctionReaderTask<E, A> = Future<A> Function(
     DoAdapterReaderTask<E> $);

--- a/packages/fpdart/lib/src/reader_task_either.dart
+++ b/packages/fpdart/lib/src/reader_task_either.dart
@@ -354,7 +354,7 @@ final class ReaderTaskEither<E, L, R>
       ReaderTaskEither<E, L, R>((env) async {
         try {
           return Right<L, R>(await run(env));
-        } on Exception catch (error, stack) {
+        } catch (error, stack) {
           return Left<L, R>(onError(error, stack));
         }
       });

--- a/packages/fpdart/lib/src/reader_task_either.dart
+++ b/packages/fpdart/lib/src/reader_task_either.dart
@@ -15,7 +15,7 @@ import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
-final class _ReaderTaskEitherThrow<L> {
+final class _ReaderTaskEitherThrow<L> implements Exception {
   final L value;
   const _ReaderTaskEitherThrow(this.value);
 }

--- a/packages/fpdart/lib/src/reader_task_either.dart
+++ b/packages/fpdart/lib/src/reader_task_either.dart
@@ -354,7 +354,7 @@ final class ReaderTaskEither<E, L, R>
       ReaderTaskEither<E, L, R>((env) async {
         try {
           return Right<L, R>(await run(env));
-        } catch (error, stack) {
+        } on Exception catch (error, stack) {
           return Left<L, R>(onError(error, stack));
         }
       });

--- a/packages/fpdart/lib/src/reader_task_either.dart
+++ b/packages/fpdart/lib/src/reader_task_either.dart
@@ -83,7 +83,7 @@ final class ReaderTaskEither<E, L, R>
     covariant ReaderTaskEither<E, L, C> Function(R r) f,
   ) =>
       ReaderTaskEither((env) => run(env).then(
-            (either) async => either.match(
+            (either) => either.match(
               left,
               (r) => f(r).run(env),
             ),
@@ -97,7 +97,7 @@ final class ReaderTaskEither<E, L, R>
     TaskEither<L, C> Function(R r) f,
   ) =>
       ReaderTaskEither((env) => run(env).then(
-            (either) async => either.match(
+            (either) => either.match(
               left,
               (r) => f(r).run(),
             ),
@@ -285,7 +285,7 @@ final class ReaderTaskEither<E, L, R>
   /// Build a [ReaderTaskEither] that returns a [Right] containing the result of running `task`.
   factory ReaderTaskEither.fromTaskEither(TaskEither<L, R> task) =>
       ReaderTaskEither(
-        (_) async => task.run(),
+        (_) => task.run(),
       );
 
   /// Build a [ReaderTaskEither] that returns a [Right] containing the result of running `io`.

--- a/packages/fpdart/lib/src/state.dart
+++ b/packages/fpdart/lib/src/state.dart
@@ -125,16 +125,17 @@ final class State<S, A> extends HKT2<_StateHKT, S, A>
   ///
   /// Same as `State.traverseList` but passing `index` in the map function.
   static State<S, List<B>> traverseListWithIndex<S, A, B>(
-      List<A> list, State<S, B> Function(A a, int i) f) => State((state) {
-      final resultList = <B>[];
-      var out = state;
-      for (var i = 0; i < list.length; i++) {
-        final (b, s) = f(list[i], i).run(out);
-        resultList.add(b);
-        out = s;
-      }
-      return (resultList, out);
-    });
+          List<A> list, State<S, B> Function(A a, int i) f) =>
+      State((state) {
+        final resultList = <B>[];
+        var out = state;
+        for (var i = 0; i < list.length; i++) {
+          final (b, s) = f(list[i], i).run(out);
+          resultList.add(b);
+          out = s;
+        }
+        return (resultList, out);
+      });
 
   /// {@macro fpdart_traverse_list_state}
   ///

--- a/packages/fpdart/lib/src/state.dart
+++ b/packages/fpdart/lib/src/state.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import 'function.dart';
 import 'state_async.dart';
 import 'typeclass/typeclass.export.dart';
@@ -6,6 +8,7 @@ import 'unit.dart';
 /// Tag the [HKT2] interface for the actual [State].
 abstract final class _StateHKT {}
 
+@immutable
 /// `State<S, A>` is used to store, update, and extract state in a functional way.
 ///
 /// `S` is a State (e.g. the current _State_ of your Bank Account).

--- a/packages/fpdart/lib/src/state.dart
+++ b/packages/fpdart/lib/src/state.dart
@@ -1,3 +1,5 @@
+// Should always be available.
+//ignore: depend_on_referenced_packages
 import 'package:meta/meta.dart';
 
 import 'function.dart';

--- a/packages/fpdart/lib/src/state.dart
+++ b/packages/fpdart/lib/src/state.dart
@@ -1,7 +1,3 @@
-// Should always be available.
-//ignore: depend_on_referenced_packages
-import 'package:meta/meta.dart';
-
 import 'function.dart';
 import 'state_async.dart';
 import 'typeclass/typeclass.export.dart';
@@ -10,7 +6,6 @@ import 'unit.dart';
 /// Tag the [HKT2] interface for the actual [State].
 abstract final class _StateHKT {}
 
-@immutable
 /// `State<S, A>` is used to store, update, and extract state in a functional way.
 ///
 /// `S` is a State (e.g. the current _State_ of your Bank Account).

--- a/packages/fpdart/lib/src/state.dart
+++ b/packages/fpdart/lib/src/state.dart
@@ -128,8 +128,7 @@ final class State<S, A> extends HKT2<_StateHKT, S, A>
   ///
   /// Same as `State.traverseList` but passing `index` in the map function.
   static State<S, List<B>> traverseListWithIndex<S, A, B>(
-      List<A> list, State<S, B> Function(A a, int i) f) {
-    return State((state) {
+      List<A> list, State<S, B> Function(A a, int i) f) => State((state) {
       final resultList = <B>[];
       var out = state;
       for (var i = 0; i < list.length; i++) {
@@ -139,7 +138,6 @@ final class State<S, A> extends HKT2<_StateHKT, S, A>
       }
       return (resultList, out);
     });
-  }
 
   /// {@macro fpdart_traverse_list_state}
   ///

--- a/packages/fpdart/lib/src/state_async.dart
+++ b/packages/fpdart/lib/src/state_async.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import 'function.dart';
 import 'state.dart';
 import 'typeclass/typeclass.export.dart';
@@ -6,6 +8,7 @@ import 'unit.dart';
 /// Tag the [HKT2] interface for the actual [StateAsync].
 abstract final class _StateAsyncHKT {}
 
+@immutable
 /// `StateAsync<S, A>` is used to store, update, and extract async state in a functional way.
 ///
 /// `S` is a State (e.g. the current _State_ of your Bank Account).

--- a/packages/fpdart/lib/src/state_async.dart
+++ b/packages/fpdart/lib/src/state_async.dart
@@ -1,3 +1,5 @@
+// Should always be available.
+//ignore: depend_on_referenced_packages
 import 'package:meta/meta.dart';
 
 import 'function.dart';

--- a/packages/fpdart/lib/src/state_async.dart
+++ b/packages/fpdart/lib/src/state_async.dart
@@ -1,7 +1,3 @@
-// Should always be available.
-//ignore: depend_on_referenced_packages
-import 'package:meta/meta.dart';
-
 import 'function.dart';
 import 'state.dart';
 import 'typeclass/typeclass.export.dart';
@@ -10,7 +6,6 @@ import 'unit.dart';
 /// Tag the [HKT2] interface for the actual [StateAsync].
 abstract final class _StateAsyncHKT {}
 
-@immutable
 /// `StateAsync<S, A>` is used to store, update, and extract async state in a functional way.
 ///
 /// `S` is a State (e.g. the current _State_ of your Bank Account).

--- a/packages/fpdart/lib/src/task.dart
+++ b/packages/fpdart/lib/src/task.dart
@@ -148,7 +148,7 @@ final class Task<A> extends HKT<_TaskHKT, A>
     Task<B> Function(A a, int i) f,
   ) =>
       Task<List<B>>(() async {
-        List<B> collect = [];
+        final collect = <B>[];
         for (var i = 0; i < list.length; i++) {
           collect.add(await f(list[i], i).run());
         }

--- a/packages/fpdart/lib/src/task_either.dart
+++ b/packages/fpdart/lib/src/task_either.dart
@@ -248,6 +248,10 @@ final class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
   factory TaskEither.fromEither(Either<L, R> either) =>
       TaskEither(() async => either);
 
+  /// Build a [TaskEither] from a `Task<Either<L, R>>`.
+  factory TaskEither.fromComposition(Task<Either<L, R>> composedTaskEither) =>
+      TaskEither(() => composedTaskEither.run());
+
   /// {@template fpdart_try_catch_task_either}
   /// Execute an async function ([Future]) and convert the result to [Either]:
   /// - If the execution is successful, returns a [Right]

--- a/packages/fpdart/lib/src/task_either.dart
+++ b/packages/fpdart/lib/src/task_either.dart
@@ -260,7 +260,7 @@ final class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
   /// Future<int> imperative(String str) async {
   ///   try {
   ///     return int.parse(str);
-  ///   } catch (e) {
+  ///   } on Exception catch (e) {
   ///     return -1; /// What does -1 means? 🤨
   ///   }
   /// }
@@ -278,7 +278,7 @@ final class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
       TaskEither<L, R>(() async {
         try {
           return Right<L, R>(await run());
-        } catch (error, stack) {
+        } on Exception catch (error, stack) {
           return Left<L, R>(onError(error, stack));
         }
       });

--- a/packages/fpdart/lib/src/task_either.dart
+++ b/packages/fpdart/lib/src/task_either.dart
@@ -249,7 +249,7 @@ final class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
       TaskEither(() async => either);
 
   /// Build a [TaskEither] from a `Task<Either<L, R>>`.
-  factory TaskEither.fromComposition(Task<Either<L, R>> composedTaskEither) =>
+  factory TaskEither.fromTaskFlatten(Task<Either<L, R>> composedTaskEither) =>
       TaskEither(() => composedTaskEither.run());
 
   /// {@template fpdart_try_catch_task_either}

--- a/packages/fpdart/lib/src/task_either.dart
+++ b/packages/fpdart/lib/src/task_either.dart
@@ -8,7 +8,7 @@ import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
-final class _TaskEitherThrow<L> {
+final class _TaskEitherThrow<L> implements Exception {
   final L value;
   const _TaskEitherThrow(this.value);
 }

--- a/packages/fpdart/lib/src/task_either.dart
+++ b/packages/fpdart/lib/src/task_either.dart
@@ -58,7 +58,7 @@ final class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
   @override
   TaskEither<L, C> flatMap<C>(covariant TaskEither<L, C> Function(R r) f) =>
       TaskEither(() => run().then(
-            (either) async => either.match(
+            (either) => either.match(
               left,
               (r) => f(r).run(),
             ),

--- a/packages/fpdart/lib/src/task_either.dart
+++ b/packages/fpdart/lib/src/task_either.dart
@@ -282,7 +282,7 @@ final class TaskEither<L, R> extends HKT2<_TaskEitherHKT, L, R>
       TaskEither<L, R>(() async {
         try {
           return Right<L, R>(await run());
-        } on Exception catch (error, stack) {
+        } catch (error, stack) {
           return Left<L, R>(onError(error, stack));
         }
       });

--- a/packages/fpdart/lib/src/task_option.dart
+++ b/packages/fpdart/lib/src/task_option.dart
@@ -200,7 +200,7 @@ final class TaskOption<R> extends HKT<_TaskOptionHKT, R>
       TaskOption<R>(() async {
         try {
           return Option.of(await run());
-        } catch (_) {
+        } on Exception catch (_) {
           return const Option.none();
         }
       });

--- a/packages/fpdart/lib/src/task_option.dart
+++ b/packages/fpdart/lib/src/task_option.dart
@@ -204,7 +204,7 @@ final class TaskOption<R> extends HKT<_TaskOptionHKT, R>
       TaskOption<R>(() async {
         try {
           return Option.of(await run());
-        } on Exception catch (_) {
+        } catch (_) {
           return const Option.none();
         }
       });

--- a/packages/fpdart/lib/src/task_option.dart
+++ b/packages/fpdart/lib/src/task_option.dart
@@ -60,7 +60,7 @@ final class TaskOption<R> extends HKT<_TaskOptionHKT, R>
   @override
   TaskOption<C> flatMap<C>(covariant TaskOption<C> Function(R r) f) =>
       TaskOption(() => run().then(
-            (option) async => option.match(
+            (option) => option.match(
               Option.none,
               (r) => f(r).run(),
             ),

--- a/packages/fpdart/lib/src/task_option.dart
+++ b/packages/fpdart/lib/src/task_option.dart
@@ -193,7 +193,7 @@ final class TaskOption<R> extends HKT<_TaskOptionHKT, R>
       );
 
   /// Build a [TaskOption] from a `Task<Option<R>>`.
-  factory TaskOption.fromComposition(Task<Option<R>> composedTaskOption) =>
+  factory TaskOption.fromTaskFlatten(Task<Option<R>> composedTaskOption) =>
       TaskOption(() => composedTaskOption.run());
 
   /// Converts a [Future] that may throw to a [Future] that never throws

--- a/packages/fpdart/lib/src/task_option.dart
+++ b/packages/fpdart/lib/src/task_option.dart
@@ -10,7 +10,7 @@ import 'typeclass/functor.dart';
 import 'typeclass/hkt.dart';
 import 'typeclass/monad.dart';
 
-final class _TaskOptionThrow {
+final class _TaskOptionThrow implements Exception {
   const _TaskOptionThrow();
 }
 

--- a/packages/fpdart/lib/src/task_option.dart
+++ b/packages/fpdart/lib/src/task_option.dart
@@ -192,6 +192,10 @@ final class TaskOption<R> extends HKT<_TaskOptionHKT, R>
         () async => predicate(value) ? Option.of(value) : const Option.none(),
       );
 
+  /// Build a [TaskOption] from a `Task<Option<R>>`.
+  factory TaskOption.fromComposition(Task<Option<R>> composedTaskOption) =>
+      TaskOption(() => composedTaskOption.run());
+
   /// Converts a [Future] that may throw to a [Future] that never throws
   /// but returns a [Option] instead.
   ///

--- a/packages/fpdart/lib/src/typeclass/alt.dart
+++ b/packages/fpdart/lib/src/typeclass/alt.dart
@@ -1,3 +1,5 @@
+import '../../fpdart.dart' show None, Option;
+import '../option.dart' show None, Option;
 import 'functor.dart';
 import 'hkt.dart';
 

--- a/packages/fpdart/lib/src/typeclass/band.dart
+++ b/packages/fpdart/lib/src/typeclass/band.dart
@@ -11,7 +11,7 @@ mixin Band<T> on Semigroup<T> {
   T combineN(T a, int n) {
     if (n <= 0) {
       throw const FormatException(
-          "Repeated combining for bands must have n > 0");
+          'Repeated combining for bands must have n > 0');
     }
 
     return n == 1 ? a : combine(a, a);

--- a/packages/fpdart/lib/src/typeclass/bounded_semilattice.dart
+++ b/packages/fpdart/lib/src/typeclass/bounded_semilattice.dart
@@ -26,7 +26,7 @@ mixin BoundedSemilattice<T> on CommutativeMonoid<T>, Semilattice<T> {
   T combineN(T a, int n) {
     if (n < 0) {
       throw const FormatException(
-          "Repeated combining for monoids must have n >= 0");
+          'Repeated combining for monoids must have n >= 0');
     } else if (n == 0) {
       return empty;
     }

--- a/packages/fpdart/lib/src/typeclass/foldable.dart
+++ b/packages/fpdart/lib/src/typeclass/foldable.dart
@@ -7,7 +7,7 @@ mixin Foldable<G, A> on HKT<G, A> {
   B foldRight<B>(B b, B Function(B acc, A a) f);
 
   B foldLeft<B>(B b, B Function(B acc, A a) f) =>
-      foldMap<Endo<B>>(dualEndoMonoid(), (a) => (B b) => f(b, a))(b);
+      foldMap<Endo<B>>(dualEndoMonoid(), (a) => (b) => f(b, a))(b);
 
   /// Fold implemented by mapping `A` values into `B` and then
   /// combining them using the given `Monoid<B>` instance.
@@ -50,7 +50,7 @@ mixin Foldable2<G, A, B> on HKT2<G, A, B> {
   C foldRight<C>(C b, C Function(C acc, B b) f);
 
   C foldLeft<C>(C b, C Function(C acc, B b) f) =>
-      foldMap<Endo<C>>(dualEndoMonoid(), (b) => (C c) => f(c, b))(b);
+      foldMap<Endo<C>>(dualEndoMonoid(), (b) => (c) => f(c, b))(b);
 
   C foldMap<C>(Monoid<C> monoid, C Function(B b) f) =>
       foldRight(monoid.empty, (c, b) => monoid.combine(f(b), c));

--- a/packages/fpdart/lib/src/typeclass/hkt.dart
+++ b/packages/fpdart/lib/src/typeclass/hkt.dart
@@ -1,5 +1,6 @@
 /// https://marcosh.github.io/post/2020/04/15/higher-kinded-types-php-solution.html
 /// https://medium.com/@gcanti/higher-kinded-types-in-flow-275b657992b7
+library;
 
 /// - [A]: Type parameter
 /// - [G]: Type constructor

--- a/packages/fpdart/lib/src/typeclass/hkt.dart
+++ b/packages/fpdart/lib/src/typeclass/hkt.dart
@@ -1,6 +1,5 @@
 /// https://marcosh.github.io/post/2020/04/15/higher-kinded-types-php-solution.html
 /// https://medium.com/@gcanti/higher-kinded-types-in-flow-275b657992b7
-library;
 
 /// - [A]: Type parameter
 /// - [G]: Type constructor

--- a/packages/fpdart/lib/src/typeclass/monoid.dart
+++ b/packages/fpdart/lib/src/typeclass/monoid.dart
@@ -33,7 +33,7 @@ mixin Monoid<T> on Semigroup<T> {
   T combineN(T a, int n) {
     if (n < 0) {
       throw const FormatException(
-          "Repeated combining for monoids must have n >= 0");
+          'Repeated combining for monoids must have n >= 0');
     } else if (n == 0) {
       return empty;
     }
@@ -72,10 +72,10 @@ class _Monoid<T> with Semigroup<T>, Monoid<T> {
 }
 
 Monoid<Endo<A>> endoMonoid<A>() =>
-    Monoid.instance<Endo<A>>(identity, (e1, e2) => (A a) => e1(e2(a)));
+    Monoid.instance<Endo<A>>(identity, (e1, e2) => (a) => e1(e2(a)));
 
 Monoid<Endo<A>> dualEndoMonoid<A>() =>
-    Monoid.instance<Endo<A>>(identity, (e1, e2) => (A a) => e2(e1(a)));
+    Monoid.instance<Endo<A>>(identity, (e1, e2) => (a) => e2(e1(a)));
 
 Monoid<bool> boolOrMonoid() => Monoid.instance(false, (a1, a2) => a1 || a2);
 Monoid<bool> boolAndMonoid() => Monoid.instance(true, (a1, a2) => a1 && a2);

--- a/packages/fpdart/lib/src/typeclass/partial_order.dart
+++ b/packages/fpdart/lib/src/typeclass/partial_order.dart
@@ -1,4 +1,7 @@
+import '../../fpdart.dart' show Order;
 import 'eq.dart';
+import 'order.dart' show Order;
+import 'typeclass.export.dart' show Order;
 
 /// The `PartialOrder` type class is used to define a
 /// [partial ordering](https://en.wikipedia.org/wiki/Partially_ordered_set) on some type `A`.

--- a/packages/fpdart/lib/src/typeclass/semigroup.dart
+++ b/packages/fpdart/lib/src/typeclass/semigroup.dart
@@ -15,7 +15,7 @@ mixin Semigroup<T> {
   T combineN(T a, int n) {
     if (n <= 0) {
       throw const FormatException(
-          "Repeated combining for semigroups must have n > 0");
+          'Repeated combining for semigroups must have n > 0');
     }
 
     return _repeatedCombineN(a, n);

--- a/packages/fpdart/lib/src/typeclass/semilattice.dart
+++ b/packages/fpdart/lib/src/typeclass/semilattice.dart
@@ -16,7 +16,7 @@ import 'semigroup.dart';
 /// > For all elements `x` and `y` of `A`, the [**least upper bound**](https://en.wikipedia.org/wiki/Infimum_and_supremum)
 /// > of the set `{x, y}` exists.
 ///
-/// See also [CommutativeSemigroup], [Bind].
+/// See also [CommutativeSemigroup].
 mixin Semilattice<T> on Band<T>, CommutativeSemigroup<T> {
   /// Given `Eq<T>`, return a `PartialOrder<T>` using the `combine`
   /// operator of `Semilattice` to determine the partial ordering. This method assumes

--- a/packages/fpdart/lib/src/unit.dart
+++ b/packages/fpdart/lib/src/unit.dart
@@ -5,7 +5,7 @@
 ///
 /// There is only one value of type [Unit].
 final class Unit {
-  static const Unit _unit = Unit._instance();
+  static const _unit = Unit._instance();
   const Unit._instance();
 
   @override

--- a/packages/fpdart/pubspec.yaml
+++ b/packages/fpdart/pubspec.yaml
@@ -5,7 +5,6 @@ description: >
 version: 1.1.1
 homepage: https://www.sandromaglione.com/
 repository: https://github.com/SandroMaglione/fpdart
-author: Maglione Sandro <lass.maglio@gmail.com>
 documentation: https://www.sandromaglione.com/articles
 issue_tracker: https://github.com/SandroMaglione/fpdart/issues
 

--- a/packages/fpdart/pubspec.yaml
+++ b/packages/fpdart/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  meta: ^1.17.0
+  meta: any
 
 dev_dependencies:
   lints: ^2.0.1

--- a/packages/fpdart/pubspec.yaml
+++ b/packages/fpdart/pubspec.yaml
@@ -12,6 +12,9 @@ issue_tracker: https://github.com/SandroMaglione/fpdart/issues
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
+dependencies:
+  meta: ^1.17.0
+
 dev_dependencies:
   lints: ^2.0.1
   test: ^1.23.1

--- a/packages/fpdart/pubspec.yaml
+++ b/packages/fpdart/pubspec.yaml
@@ -11,11 +11,13 @@ issue_tracker: https://github.com/SandroMaglione/fpdart/issues
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
+dependencies:
+  collection: ^1.17.2
+
 dev_dependencies:
   lints: ^2.0.1
   test: ^1.23.1
   glados: ^1.1.6
-  collection: ^1.17.2
 
 screenshots:
   - description: "Basic usage of fpdart Option, Either, TaskEither types."

--- a/packages/fpdart/pubspec.yaml
+++ b/packages/fpdart/pubspec.yaml
@@ -11,9 +11,6 @@ issue_tracker: https://github.com/SandroMaglione/fpdart/issues
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
-dependencies:
-  meta: any
-
 dev_dependencies:
   lints: ^2.0.1
   test: ^1.23.1

--- a/packages/fpdart/pubspec.yaml
+++ b/packages/fpdart/pubspec.yaml
@@ -11,13 +11,11 @@ issue_tracker: https://github.com/SandroMaglione/fpdart/issues
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
-dependencies:
-  collection: ^1.17.2
-
 dev_dependencies:
   lints: ^2.0.1
   test: ^1.23.1
   glados: ^1.1.6
+  collection: ^1.17.2
 
 screenshots:
   - description: "Basic usage of fpdart Option, Either, TaskEither types."

--- a/packages/fpdart/test/src/extension/iterable_extension_test.dart
+++ b/packages/fpdart/test/src/extension/iterable_extension_test.dart
@@ -203,6 +203,54 @@ void main() {
       });
     });
 
+    group('singleOption', () {
+      test('Some', () {
+        const list1 = [1];
+        final ap = list1.singleOption;
+        expect(ap, isA<Some>());
+        expect(ap.getOrElse(() => -1), 1);
+      });
+      test('None (empty list)', () {
+        const list1 = <int>[];
+        final ap = list1.singleOption;
+        expect(ap, isA<None>());
+        expect(ap.getOrElse(() => -1), -1);
+      });
+      test('None (multiple elements)', () {
+        const list1 = [1, 2];
+        final ap = list1.singleOption;
+        expect(ap, isA<None>());
+        expect(ap.getOrElse(() => -1), -1);
+      });
+    });
+
+    group('singleWhereOption', () {
+      test('Some', () {
+        const list1 = [1];
+        final ap = list1.singleWhereOption((elem) => elem == 1);
+        expect(ap, isA<Some>());
+        expect(ap.getOrElse(() => -1), 1);
+      });
+      test('None (empy list)', () {
+        const list1 = [];
+        final ap = list1.singleWhereOption((elem) => elem == 1);
+        expect(ap, isA<None>());
+        expect(ap.getOrElse(() => -1), -1);
+      });
+      test('None (no matching element)', () {
+        const list1 = [1];
+        final ap = list1.singleWhereOption((elem) => elem == 2);
+        expect(ap, isA<None>());
+        expect(ap.getOrElse(() => -1), -1);
+      });
+      test('None (multiple matching element)', () {
+        const list1 = [1, 1];
+        final ap = list1.singleWhereOption((elem) => elem == 1);
+        expect(ap, isA<None>());
+        expect(ap.getOrElse(() => -1), -1);
+      });
+    });
+
     group('init', () {
       test('Some', () {
         final list1 = [1, 2, 3, 4];
@@ -218,6 +266,40 @@ void main() {
         final ap = list1.lastOption;
         expect(ap, isA<Some>());
         expect(ap.getOrElse(() => -1), 4);
+      });
+    });
+
+    group('lastWhereOption', () {
+      test('Some', () {
+        const list1 = [1, 2, 3, 4, 5, 6];
+        final ap = list1.lastWhereOption((elem) => elem.isEven);
+        expect(ap, isA<Some>());
+        expect(ap.getOrElse(() => -1), 6);
+      });
+      test('None (empy list)', () {
+        const list1 = [];
+        final ap = list1.lastWhereOption((elem) => elem == 1);
+        expect(ap, isA<None>());
+        expect(ap.getOrElse(() => -1), -1);
+      });
+      test('None (no matching element)', () {
+        const list1 = [1, 3, 5, 7];
+        final ap = list1.lastWhereOption((elem) => elem.isEven);
+        expect(ap, isA<None>());
+        expect(ap.getOrElse(() => -1), -1);
+      });
+      test('Handles first/last element edge cases correctly', () {
+        const list1 = [2, 1, 3, 4];
+
+        final ap1 = list1.lastWhereOption((elem) => elem == 2);
+        // First element is last matching
+        expect(ap1, isA<Some>());
+        expect(ap1.getOrElse(() => -1), 2);
+
+        final ap2 = list1.lastWhereOption((elem) => elem == 4);
+        // Last element is matching
+        expect(ap2, isA<Some>());
+        expect(ap2.getOrElse(() => -1), 4);
       });
     });
 

--- a/packages/fpdart/test/src/extension/task_extension_test.dart
+++ b/packages/fpdart/test/src/extension/task_extension_test.dart
@@ -1,0 +1,45 @@
+import 'package:fpdart/fpdart.dart';
+
+import '../utils/utils.dart';
+
+void main() {
+  group('CompositionOptionExtension', () {
+    group('toTaskOptionFlat', () {
+      test('Some', () async {
+        final task = Task(() async => Option.of(10));
+        final convert = task.toTaskOptionFlat();
+        final r = await convert.run();
+        r.matchTestSome((r) {
+          expect(r, 10);
+        });
+      });
+      test('None', () async {
+        final task = Task(() async => Option.none());
+        final convert = task.toTaskOptionFlat();
+        final r = await convert.run();
+        expect(r, isA<None>());
+      });
+    });
+  });
+
+  group('CompositionEitherExtension', () {
+    group('toTaskEitherFlat', () {
+      test('Right', () async {
+        final task = Task(() async => Either.of(10));
+        final convert = task.toTaskEitherFlat();
+        final r = await convert.run();
+        r.matchTestRight((r) {
+          expect(r, 10);
+        });
+      });
+      test('Left', () async {
+        final task = Task(() async => Either.left('none'));
+        final convert = task.toTaskEitherFlat();
+        final r = await convert.run();
+        r.matchTestLeft((l) {
+          expect(l, 'none');
+        });
+      });
+    });
+  });
+}

--- a/packages/fpdart/test/src/task_either_test.dart
+++ b/packages/fpdart/test/src/task_either_test.dart
@@ -373,6 +373,24 @@ void main() {
       });
     });
 
+    group('fromTaskFlatten', () {
+      test('Right', () async {
+        final task = TaskEither<String, int>.fromTaskFlatten(Task.of(Either.of(10)));
+        final r = await task.run();
+        r.match((_) {
+          fail('should be right');
+        }, (r) => expect(r, 10));
+      });
+
+      test('Left', () async {
+        final task = TaskEither<String, int>.fromTaskFlatten(Task.of(Either.left('error')));
+        final r = await task.run();
+        r.match((l) => expect(l, 'error'), (_) {
+          fail('should be left');
+        });
+      });
+    });
+
     group('fromOption', () {
       test('Right', () async {
         final task =

--- a/packages/fpdart/test/src/task_either_test.dart
+++ b/packages/fpdart/test/src/task_either_test.dart
@@ -375,7 +375,8 @@ void main() {
 
     group('fromTaskFlatten', () {
       test('Right', () async {
-        final task = TaskEither<String, int>.fromTaskFlatten(Task.of(Either.of(10)));
+        final task =
+            TaskEither<String, int>.fromTaskFlatten(Task.of(Either.of(10)));
         final r = await task.run();
         r.match((_) {
           fail('should be right');
@@ -383,7 +384,8 @@ void main() {
       });
 
       test('Left', () async {
-        final task = TaskEither<String, int>.fromTaskFlatten(Task.of(Either.left('error')));
+        final task = TaskEither<String, int>.fromTaskFlatten(
+            Task.of(Either.left('error')));
         final r = await task.run();
         r.match((l) => expect(l, 'error'), (_) {
           fail('should be left');

--- a/packages/fpdart/test/src/task_option_test.dart
+++ b/packages/fpdart/test/src/task_option_test.dart
@@ -240,6 +240,22 @@ void main() {
       });
     });
 
+    group('fromTaskFlatten', () {
+      test('Some', () async {
+        final task = TaskOption<int>.fromTaskFlatten(Task.of(some(10)));
+        final result = await task.run();
+        result.matchTestSome((r) {
+          expect(r, 10);
+        });
+      });
+
+      test('None', () async {
+        final taskOption = TaskOption<int>.fromTaskFlatten(Task.of(none()));
+        final result = await taskOption.run();
+        expect(result, isA<None>());
+      });
+    });
+
     test('fromTask', () async {
       final task = TaskOption<int>.fromTask(Task(() async => 10));
       final r = await task.run();


### PR DESCRIPTION
1. Lints fixed by `dart fix --apply`
[fix_lints.txt](https://github.com/user-attachments/files/21706369/fix_lints.txt)
2. Add `.fromComposition` constructors for `Task<Option<T>>` -> `TaskOption<T>` and `Task<Either<L, R>>` -> `TaskEither<L, R>`
3. Manual minor fixes
    - catch (error, stack) -> on Exception catch (error, stack)
    -  function tear-offs
    - No async if not using await
    - lint-ignore `dynamic` warning with explanations
    - Don't throw instances of classes that don't extend either 'Exception' or 'Error'
    - Deprecated author tag used
    - @immutabile tag needed from meta library to override `==` and `toString()`